### PR TITLE
WIP : Default folder environment variable

### DIFF
--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -157,6 +157,10 @@ def valid_arguments(arguments: dict) -> bool:
             "Kicad",
             "easyeda2kicad",
         )
+        # Use environment variables if EASYEDA2KICAD_DIR is set
+        # Else, use default_folder
+        env_folder = os.getenv("EASYEDA2KICAD_DIR", default_folder)
+        default_folder = os.path.abspath(env_folder)
         if not os.path.isdir(default_folder):
             os.mkdir(default_folder)
 


### PR DESCRIPTION
Thanks for this package ! It provides a nice way to work efficiently with LCSC components !

I added a feature that provides a way to set an environment variable called `EASYEDA2KICAD_DIR`, instead on relying on a hard-coded default folder.

It seems like this feature would affect :
- the documentation on adding libraries to KiCad
- this error line :

https://github.com/uPesy/easyeda2kicad.py/blob/dev/easyeda2kicad/__main__.py#L135