### PR TITLE
Recursivily create default_folder

### DIFF
--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -158,7 +158,7 @@ def valid_arguments(arguments: dict) -> bool:
             "easyeda2kicad",
         )
         if not os.path.isdir(default_folder):
-            os.mkdir(default_folder)
+            os.makedirs(default_folder, exist_ok=True)
 
         base_folder = default_folder
         lib_name = "easyeda2kicad"


### PR DESCRIPTION
If no output folder is supplied, and thus the default_folder is used, the application currently tries to create a new folder under `Documents/Kicad`. However, if some of these folders do not exist, python crashes with a nasty traceback.

```
-- easyeda2kicad.py v0.6.0 --
Traceback (most recent call last):
  File "/usr/bin/easyeda2kicad", line 33, in <module>
    sys.exit(load_entry_point('easyeda2kicad==0.6.0', 'console_scripts', 'easyeda2kicad')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/easyeda2kicad/__main__.py", line 237, in main
    if not valid_arguments(arguments=arguments):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/easyeda2kicad/__main__.py", line 161, in valid_arguments
    os.mkdir(default_folder)
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/Documents/Kicad/easyeda2kicad'
```

Instead, use os.makedirs, which has been available in python since 3.2 which avoids this issue altogether.