### PR TITLE
Warn and avoid crash on empty or unparseable path or polygon.

### DIFF
--- a/easyeda2kicad/kicad/export_kicad_symbol.py
+++ b/easyeda2kicad/kicad/export_kicad_symbol.py
@@ -226,18 +226,20 @@ def convert_ee_polylines(
         if isinstance(ee_polyline, EeSymbolPolygon) or ee_polyline.fill_color:
             x_points.append(x_points[0])
             y_points.append(y_points[0])
-
-        kicad_polygon = KiSymbolPolygon(
-            points=[
-                [x_points[i], y_points[i]]
-                for i in range(min(len(x_points), len(y_points)))
-            ],
-            points_number=min(len(x_points), len(y_points)),
-            is_closed=x_points[0] == x_points[-1] and y_points[0] == y_points[-1],
-        )
-
-        kicad_polygons.append(kicad_polygon)
-
+        if (len(x_points) > 0 and len(y_points) > 0):
+            kicad_polygon = KiSymbolPolygon(
+                points=[
+                    [x_points[i], y_points[i]]
+                    for i in range(min(len(x_points), len(y_points)))
+                ],
+                points_number=min(len(x_points), len(y_points)),
+                is_closed=x_points[0] == x_points[-1] and y_points[0] == y_points[-1],
+            )
+    
+            kicad_polygons.append(kicad_polygon)
+        else:
+            logging.warning("Skipping polygon with no parseable points")
+            
     return kicad_polygons
 
 
@@ -281,17 +283,19 @@ def convert_ee_paths(
         # if ee_path.fill_color:
         #     x_points.append(x_points[0])
         #     y_points.append(y_points[0])
+        if (len(x_points) > 0 and len(y_points) > 0):
+            ki_polygon = KiSymbolPolygon(
+                points=[
+                    [x_points[i], y_points[i]]
+                    for i in range(min(len(x_points), len(y_points)))
+                ],
+                points_number=min(len(x_points), len(y_points)),
+                is_closed=x_points[0] == x_points[-1] and y_points[0] == y_points[-1],
+            )
 
-        ki_polygon = KiSymbolPolygon(
-            points=[
-                [x_points[i], y_points[i]]
-                for i in range(min(len(x_points), len(y_points)))
-            ],
-            points_number=min(len(x_points), len(y_points)),
-            is_closed=x_points[0] == x_points[-1] and y_points[0] == y_points[-1],
-        )
-
-        kicad_polygons.append(ki_polygon)
+            kicad_polygons.append(ki_polygon)
+        else:
+            logging.warning("Skipping path with no parseable points")
 
     return kicad_polygons, kicad_beziers
 


### PR DESCRIPTION
Ran into crashes with several parts that have unsupported or empty paths/polygons due to indexing errors. An example of a part that crashes is C397342:
```
  File "easyeda2kicad/kicad/export_kicad_symbol.py", line 291, in convert_ee_paths
    is_closed=x_points[0] == x_points[-1] and y_points[0] == y_points[-1],
IndexError: list index out of range
```
This PR warns when a path/polygon has no parseable points, and avoids the crash so the tool can continue to import the rest of the symbol:
```
[WARNING] Skipping path with no parseable points
```

Thanks for the useful tool!