### PR TITLE
Fix conversion of pads using custom polygons.

### DIFF
--- a/easyeda2kicad/kicad/export_kicad_footprint.py
+++ b/easyeda2kicad/kicad/export_kicad_footprint.py
@@ -257,15 +257,20 @@ class ExporterFootprintKicad:
                         f"PAD ${ee_pad.id} is a polygon, but has no points defined"
                     )
                 else:
-                    # Replace pad width & height since kicad doesn't care
-                    ki_pad.width = 1.0
-                    ki_pad.height = 1.0
+                    # Set the pad width and height to the smallest value allowed by KiCad.
+                    # KiCad tries to draw a pad that forms the base of the polygon,
+                    # but this is often unnecessary and should be disabled.
+                    ki_pad.width = 0.005
+                    ki_pad.height = 0.005
 
-                    # Generate polygon
+                    # The points of the polygon always seem to correspond to coordinates when orientation=0.
+                    ki_pad.orientation = 0
+
+                    # Generate polygon with coordinates relative to the base pad's position.
                     path = "".join(
                         "(xy {} {})".format(
-                            round(point_list[i] - self.input.bbox.x, 2),
-                            round(point_list[i + 1] - self.input.bbox.y, 2),
+                            round(point_list[i] - self.input.bbox.x - ki_pad.pos_x, 2),
+                            round(point_list[i + 1] - self.input.bbox.y - ki_pad.pos_y, 2),
                         )
                         for i in range(0, len(point_list), 2)
                     )


### PR DESCRIPTION
This change addresses an issue where pads using custom polygons are incorrectly converted. The issue can be summarized in two points. First, KiCad uses the specified width and height for the polygon to draw its base pad and seems to ignore rotation. Second, each point in the polygon is determined by the coordinates based on pos_x and pos_y of its base pad.

I tested this patch with the following footprints:

| LCSC# | Expected | Current | This PR |
|---|---|---|---|
|[C4363942](https://jlcpcb.com/partdetail/TexasInstruments-TXU0304DTRR/C4363942)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/899240a1-e66e-4899-9452-deda9da8f93f)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/0a2c5d4e-2173-4351-aec6-2b74a28240e5)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/8708e0d0-9921-46c8-8214-7070665129a7)|
|[C603662](https://jlcpcb.com/partdetail/Onsemi-NCP167AMX330TBG/C603662)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/b47d4f2a-cc02-4596-a7de-acbb8d2e3905)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/64a0c948-bdf9-41f3-9f45-0883590941ac)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/1b12c91b-37b5-45dd-9d7c-67430415d8c3)|
|[C3210761](https://jlcpcb.com/partdetail/TexasInstruments-LM73100RPWR/C3210761) (#124)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/1e1c22ea-cea9-4314-9deb-6b88053946f1)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/7739a9e4-e6a5-4f19-95c8-f3784853631f)|![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/3323a691-4a29-4017-afae-e7dcbafd2acf)|







