### PR TITLE
Fix polygons getting thicker

### DIFF
--- a/easyeda2kicad/kicad/export_kicad_footprint.py
+++ b/easyeda2kicad/kicad/export_kicad_footprint.py
@@ -278,7 +278,7 @@ class ExporterFootprintKicad:
                     )
                     ki_pad.polygon = (
                         "\n\t\t(primitives \n\t\t\t(gr_poly \n\t\t\t\t(pts"
-                        f" {path}\n\t\t\t\t) \n\t\t\t\t(width 0.1) \n\t\t\t)\n\t\t)\n\t"
+                        f" {path}\n\t\t\t\t) \n\t\t\t\t(width 0) \n\t\t\t)\n\t\t)\n\t"
                     )
 
             self.output.pads.append(ki_pad)


### PR DESCRIPTION
#134 This is most noticeable in the last image on previous PR, where each of the polygon paths has "padding" that extends outward from expected. I found that for small footprints, this difference results in margin overlapping. We can avoid this problem by setting the width of each path to 0.

| Current | This PR |
|---|---|
| ![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/49af3779-3e5c-4ff7-b4f3-f9636a65d509) | ![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/7aedfd26-7499-4387-8067-0aa4fa6b3706) |

However, as we can see, the pad minimized in the previous PR appears as a small circle in the polygon's center. I am working on a way to remove this.

![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/de332df7-67aa-4675-a147-0acfa5a7b670)
