### PR TITLE
Fix edge case in arc conversion

### DIFF
--- a/easyeda2kicad/kicad/export_kicad_footprint.py
+++ b/easyeda2kicad/kicad/export_kicad_footprint.py
@@ -94,7 +94,8 @@ def compute_arc(
     p = ux * vx + uy * vy
     sign = -1 if (ux * vy - uy * vx) < 0 else 1
     if n != 0:
-        angle_extent = to_degrees(sign * acos(p / n)) if abs(p / n) < 1 else 360 + 359
+        p_n = max(-1, min(1, p / n))
+        angle_extent = to_degrees(sign * acos(p_n))
     else:
         angle_extent = 360 + 359
     if not (sweep_flag) and angle_extent > 0:


### PR DESCRIPTION
Fix #139 .

`p / n`, namely the cosine of the `angle_extent`, is by definition supposed to be within [-1,1]. However, due to floating-point arithmetic errors, `abs(p / n)` can sometimes exceed 1 (in this case, it was 1.0000000000000004). By clamping `p / n` in advance, we can correctly calculate angle.

Expected | Current | This PR
-- | -- | --
![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/9492a05b-092d-4404-8c1a-0cf096382446) | ![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/33a112e9-61e7-456c-9c6b-b46219cf0b24) | ![image](https://github.com/uPesy/easyeda2kicad.py/assets/57749636/f9067876-73af-4c19-a58e-0a37d6bf4d53)
