### PR TITLE
Allow converting symbols with multiple units to v6

### DIFF
--- a/easyeda2kicad/easyeda/easyeda_importer.py
+++ b/easyeda2kicad/easyeda/easyeda_importer.py
@@ -127,18 +127,37 @@ class EasyedaSymbolImporter:
                 lcsc_id=ee_data["lcsc"].get("number", None),
                 jlc_id=ee_data_info.get("BOM_JLCPCB Part Class", None),
             ),
-            bbox=EeSymbolBbox(
-                x=float(ee_data["dataStr"]["head"]["x"]),
-                y=float(ee_data["dataStr"]["head"]["y"]),
-            ),
         )
 
-        for line in ee_data["dataStr"]["shape"]:
-            designator = line.split("~")[0]
-            if designator in easyeda_handlers:
-                easyeda_handlers[designator](line, new_ee_symbol)
-            else:
-                logging.warning(f"Unknow symbol designator : {designator}")
+        if "subparts" in ee_data:
+            for unit in ee_data["subparts"]:
+                new_ee_unit = EeSymbolUnit(
+                    bbox=EeSymbolBbox(
+                        x=float(ee_data["dataStr"]["head"]["x"]),
+                        y=float(ee_data["dataStr"]["head"]["y"]),
+                    ),
+                )
+                for line in unit["dataStr"]["shape"]:
+                    designator = line.split("~")[0]
+                    if designator in easyeda_handlers:
+                        easyeda_handlers[designator](line, new_ee_unit)
+                    else:
+                        logging.warning(f"Unknow symbol designator : {designator}")
+                new_ee_symbol.units.append(new_ee_unit)
+        else:
+            new_ee_unit = EeSymbolUnit(
+                bbox=EeSymbolBbox(
+                    x=float(ee_data["dataStr"]["head"]["x"]),
+                    y=float(ee_data["dataStr"]["head"]["y"]),
+                ),
+            )
+            for line in ee_data["dataStr"]["shape"]:
+                designator = line.split("~")[0]
+                if designator in easyeda_handlers:
+                    easyeda_handlers[designator](line, new_ee_unit)
+                else:
+                    logging.warning(f"Unknow symbol designator : {designator}")
+            new_ee_symbol.units.append(new_ee_unit)
 
         return new_ee_symbol
 

--- a/easyeda2kicad/easyeda/parameters_easyeda.py
+++ b/easyeda2kicad/easyeda/parameters_easyeda.py
@@ -291,10 +291,8 @@ class EeSymbolInfo:
     lcsc_id: str = ""
     jlc_id: str = ""
 
-
 @dataclass
-class EeSymbol:
-    info: EeSymbolInfo
+class EeSymbolUnit:
     bbox: EeSymbolBbox
     pins: List[EeSymbolPin] = field(default_factory=list)
     rectangles: List[EeSymbolRectangle] = field(default_factory=list)
@@ -304,6 +302,11 @@ class EeSymbol:
     polylines: List[EeSymbolPolyline] = field(default_factory=list)
     polygons: List[EeSymbolPolygon] = field(default_factory=list)
     paths: List[EeSymbolPath] = field(default_factory=list)
+
+@dataclass
+class EeSymbol:
+    info: EeSymbolInfo
+    units: List[EeSymbolUnit] = field(default_factory=list)
 
 
 # ------------------------- Footprint -------------------------

--- a/easyeda2kicad/kicad/export_kicad_symbol.py
+++ b/easyeda2kicad/kicad/export_kicad_symbol.py
@@ -314,42 +314,46 @@ def convert_to_kicad(ee_symbol: EeSymbol, kicad_version: KicadVersion) -> KiSymb
 
     kicad_symbol = KiSymbol(
         info=ki_info,
-        pins=convert_ee_pins(
-            ee_pins=ee_symbol.pins, ee_bbox=ee_symbol.bbox, kicad_version=kicad_version
-        ),
-        rectangles=convert_ee_rectangles(
-            ee_rectangles=ee_symbol.rectangles,
-            ee_bbox=ee_symbol.bbox,
-            kicad_version=kicad_version,
-        ),
-        circles=convert_ee_circles(
-            ee_circles=ee_symbol.circles,
-            ee_bbox=ee_symbol.bbox,
-            kicad_version=kicad_version,
-        ),
-        arcs=convert_ee_arcs(
-            ee_arcs=ee_symbol.arcs, ee_bbox=ee_symbol.bbox, kicad_version=kicad_version
-        ),
-    )
-    kicad_symbol.circles += convert_ee_ellipses(
-        ee_ellipses=ee_symbol.ellipses,
-        ee_bbox=ee_symbol.bbox,
-        kicad_version=kicad_version,
     )
 
-    kicad_symbol.polygons, kicad_symbol.beziers = convert_ee_paths(
-        ee_paths=ee_symbol.paths, ee_bbox=ee_symbol.bbox, kicad_version=kicad_version
-    )
-    kicad_symbol.polygons += convert_ee_polylines(
-        ee_polylines=ee_symbol.polylines,
-        ee_bbox=ee_symbol.bbox,
-        kicad_version=kicad_version,
-    )
-    kicad_symbol.polygons += convert_ee_polygons(
-        ee_polygons=ee_symbol.polygons,
-        ee_bbox=ee_symbol.bbox,
-        kicad_version=kicad_version,
-    )
+    for ee_unit in ee_symbol.units:
+        kicad_unit = KiSymbolUnit(
+            pins=convert_ee_pins(
+                ee_pins=ee_unit.pins, ee_bbox=ee_unit.bbox, kicad_version=kicad_version
+            ),
+            rectangles=convert_ee_rectangles(
+                ee_rectangles=ee_unit.rectangles,
+                ee_bbox=ee_unit.bbox,
+                kicad_version=kicad_version,
+            ),
+            circles=convert_ee_circles(
+                ee_circles=ee_unit.circles,
+                ee_bbox=ee_unit.bbox,
+                kicad_version=kicad_version,
+            ),
+            arcs=convert_ee_arcs(
+                ee_arcs=ee_unit.arcs, ee_bbox=ee_unit.bbox, kicad_version=kicad_version
+            ),
+        )
+        kicad_unit.circles += convert_ee_ellipses(
+            ee_ellipses=ee_unit.ellipses,
+            ee_bbox=ee_unit.bbox,
+            kicad_version=kicad_version,
+        )
+        kicad_unit.polygons, kicad_unit.beziers = convert_ee_paths(
+            ee_paths=ee_unit.paths, ee_bbox=ee_unit.bbox, kicad_version=kicad_version
+        )
+        kicad_unit.polygons += convert_ee_polylines(
+            ee_polylines=ee_unit.polylines,
+            ee_bbox=ee_unit.bbox,
+            kicad_version=kicad_version,
+        )
+        kicad_unit.polygons += convert_ee_polygons(
+            ee_polygons=ee_unit.polygons,
+            ee_bbox=ee_unit.bbox,
+            kicad_version=kicad_version,
+        )
+        kicad_symbol.units.append(kicad_unit)
 
     return kicad_symbol
 

--- a/easyeda2kicad/kicad/parameters_kicad_symbol.py
+++ b/easyeda2kicad/kicad/parameters_kicad_symbol.py
@@ -593,8 +593,7 @@ class KiSymbolBezier:
 
 # ---------------- SYMBOL ----------------
 @dataclass
-class KiSymbol:
-    info: KiSymbolInfo
+class KiSymbolUnit:
     pins: List[KiSymbolPin] = field(default_factory=lambda: [])
     rectangles: List[KiSymbolRectangle] = field(default_factory=lambda: [])
     circles: List[KiSymbolCircle] = field(default_factory=lambda: [])
@@ -602,30 +601,84 @@ class KiSymbol:
     polygons: List[KiSymbolPolygon] = field(default_factory=lambda: [])
     beziers: List[KiSymbolBezier] = field(default_factory=lambda: [])
 
-    def export_handler(self, kicad_version: str):
-        # Get y_min and y_max to put component info
-        self.info.y_low = min(pin.pos_y for pin in self.pins) if self.pins else 0
-        self.info.y_high = max(pin.pos_y for pin in self.pins) if self.pins else 0
+    def get_min_y(self):
+        return min(pin.pos_y for pin in self.pins) if self.pins else float("+inf")
 
-        sym_export_data = {}
+    def get_max_y(self):
+        return max(pin.pos_y for pin in self.pins) if self.pins else float("-inf")
+
+    def export_handler(self, kicad_version: str):
+        unit_export_data = {}
         for _field in fields(self):
             shapes = getattr(self, _field.name)
             if isinstance(shapes, list):
-                sym_export_data.setdefault(_field.name, [])
+                unit_export_data.setdefault(_field.name, [])
                 for sub_symbol in shapes:
-                    sym_export_data[_field.name].append(
+                    unit_export_data[_field.name].append(
                         getattr(sub_symbol, f"export_v{kicad_version}")()
                     )
             else:
-                sym_export_data[_field.name] = getattr(
+                unit_export_data[_field.name] = getattr(
                     shapes, f"export_v{kicad_version}"
                 )()
+        return unit_export_data
+
+    def export_v6(self, unit_library_id):
+        unit_export_data = self.export_handler(kicad_version="6")
+        unit_pins = unit_export_data.pop("pins")
+        unit_graphic_items = itertools.chain.from_iterable(unit_export_data.values())
+
+        return textwrap.indent(
+            textwrap.dedent(
+                """
+              (symbol "{library_id}"
+                {graphic_items}
+                {pins}
+              )"""
+                ),
+            "  " * 2,
+        ).format(
+            library_id=unit_library_id,
+            graphic_items=textwrap.indent(
+                textwrap.dedent("".join(unit_graphic_items)), "  " * 3
+            ),
+            pins=textwrap.indent(textwrap.dedent("".join(unit_pins)), "  " * 3),
+        )
+
+@dataclass
+class KiSymbol:
+    info: KiSymbolInfo
+    units: List[KiSymbolUnit] = field(default_factory=lambda: [])
+
+    def export_handler(self, kicad_version: str):
+        # Get y_min and y_max to put component info
+        self.info.y_low = min(unit.get_min_y() for unit in self.units)
+        if self.info.y_low == float("+inf"):
+            self.info.y_low = 0
+        self.info.y_high = max(unit.get_max_y() for unit in self.units)
+        if self.info.y_high == float("-inf"):
+            self.info.y_high = 0
+
+        sym_export_data = {}
+        if isinstance(self.info, list):
+            sym_export_data.setdefault("info", [])
+            for sub_symbol in self.info:
+                sym_export_data["info"].append(
+                    getattr(sub_symbol, f"export_v{kicad_version}")()
+                )
+        else:
+            sym_export_data["info"] = getattr(
+                self.info, f"export_v{kicad_version}"
+            )()
+
         return sym_export_data
 
     def export_v5(self):
         sym_export_data = self.export_handler(kicad_version="5")
         sym_info = sym_export_data.pop("info")
-        sym_graphic_items = itertools.chain.from_iterable(sym_export_data.values())
+        if len(self.units) > 1:
+            print("multiple units not supported for v5, only the first will be exported")
+        sym_graphic_items = itertools.chain.from_iterable(self.units[0].export_handler(kicad_version="5"))
 
         return (
             "#\n#"
@@ -635,8 +688,14 @@ class KiSymbol:
     def export_v6(self):
         sym_export_data = self.export_handler(kicad_version="6")
         sym_info = sym_export_data.pop("info")
-        sym_pins = sym_export_data.pop("pins")
-        sym_graphic_items = itertools.chain.from_iterable(sym_export_data.values())
+
+        unitstrings = []
+        unitnumber = 1 if len(self.units) > 1 else 0
+        for unit in self.units:
+            unitstrings.append(
+                unit.export_v6(f"{sanitize_fields(self.info.name)}_{unitnumber}_1")
+            )
+            unitnumber += 1
 
         return textwrap.indent(
             textwrap.dedent(
@@ -645,10 +704,7 @@ class KiSymbol:
               (in_bom yes)
               (on_board yes)
               {symbol_properties}
-              (symbol "{library_id}_0_1"
-                {graphic_items}
-                {pins}
-              )
+              {units}
             )"""
             ),
             "  ",
@@ -657,10 +713,7 @@ class KiSymbol:
             symbol_properties=textwrap.indent(
                 textwrap.dedent("".join(sym_info)), "  " * 2
             ),
-            graphic_items=textwrap.indent(
-                textwrap.dedent("".join(sym_graphic_items)), "  " * 3
-            ),
-            pins=textwrap.indent(textwrap.dedent("".join(sym_pins)), "  " * 3),
+            units="".join(unitstrings),
         )
 
     def export(self, kicad_version: KicadVersion) -> str:

--- a/easyeda2kicad/kicad/parameters_kicad_symbol.py
+++ b/easyeda2kicad/kicad/parameters_kicad_symbol.py
@@ -678,7 +678,7 @@ class KiSymbol:
         sym_info = sym_export_data.pop("info")
         if len(self.units) > 1:
             print("multiple units not supported for v5, only the first will be exported")
-        sym_graphic_items = itertools.chain.from_iterable(self.units[0].export_handler(kicad_version="5"))
+        sym_graphic_items = itertools.chain.from_iterable(self.units[0].export_handler(kicad_version="5").values())
 
         return (
             "#\n#"


### PR DESCRIPTION
Fix #69 

This changes some of the symbol code so that it will correctly import symbols with multiple units (easyeda seems to call them subparts). I've only done this for v6 symbols because I don't use v5 (currently using kicad 8.0) and so don't have examples for correct multi-unit v5 files. v5 should still work, but only export the first unit.