### PR TITLE
Escape ":" in symbol names

### DIFF
--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -25,7 +25,10 @@ from easyeda2kicad.helpers import (
 from easyeda2kicad.kicad.export_kicad_3d_model import Exporter3dModelKicad
 from easyeda2kicad.kicad.export_kicad_footprint import ExporterFootprintKicad
 from easyeda2kicad.kicad.export_kicad_symbol import ExporterSymbolKicad
-from easyeda2kicad.kicad.parameters_kicad_symbol import KicadVersion
+from easyeda2kicad.kicad.parameters_kicad_symbol import (
+    KicadVersion,
+    sanitize_fields,
+)
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -262,7 +265,7 @@ def main(argv: List[str] = sys.argv[1:]) -> int:
 
         is_id_already_in_symbol_lib = id_already_in_symbol_lib(
             lib_path=f"{arguments['output']}.{sym_lib_ext}",
-            component_name=easyeda_symbol.info.name,
+            component_name=sanitize_fields(easyeda_symbol.info.name),
             kicad_version=kicad_version,
         )
 
@@ -281,7 +284,7 @@ def main(argv: List[str] = sys.argv[1:]) -> int:
         if is_id_already_in_symbol_lib:
             update_component_in_symbol_lib_file(
                 lib_path=f"{arguments['output']}.{sym_lib_ext}",
-                component_name=easyeda_symbol.info.name,
+                component_name=sanitize_fields(easyeda_symbol.info.name),
                 component_content=kicad_symbol_lib,
                 kicad_version=kicad_version,
             )

--- a/easyeda2kicad/kicad/parameters_kicad_symbol.py
+++ b/easyeda2kicad/kicad/parameters_kicad_symbol.py
@@ -97,7 +97,7 @@ ki_box_fill_v5_format = {
 
 
 def sanitize_fields(name: str) -> str:
-    return name.replace(" ", "").replace("/", "_")
+    return name.replace(" ", "").replace("/", "_").replace(":", "{colon}")
 
 
 def apply_text_style(text: str, kicad_version: KicadVersion) -> str:


### PR DESCRIPTION
Fixes #88

I was importing C2859183, which has a symbol named "MT40A1G8SA-062E:R" when I ran into this problem, so I wrote this simple fix.

I also fixed an oversight in the duplicate detection that I found when testing, where if ":" was in the symbol name it would not find the existing symbol. This presumably could have happened with " " and "/" too as they are also replaced in symbol names.