### PR TITLE
Fix: Allow libraries that include subparts to be parsed

### DIFF
--- a/easyeda2kicad/easyeda/easyeda_importer.py
+++ b/easyeda2kicad/easyeda/easyeda_importer.py
@@ -6,24 +6,38 @@ from easyeda2kicad.easyeda.easyeda_api import EasyedaApi
 from easyeda2kicad.easyeda.parameters_easyeda import *
 
 
-def add_easyeda_pin(pin_data: str, ee_symbol: EeSymbol):
+def shift_paths_x(paths: str, add_value: float):
+    numbers = list(map(float, paths.split()))
+
+    # Add `add_value` to every second number
+    for i in range(0, len(numbers), 2):  # Start from index 1 and step by 2
+        numbers[i] += add_value
+
+    # Convert back to a space-separated string
+    return " ".join(map(str, numbers))
+
+
+def add_easyeda_pin(pin_data: str, ee_symbol: EeSymbol, shiftX=0):
     segments = pin_data.split("^^")
     ee_segments = [seg.split("~") for seg in segments]
 
     pin_settings = EeSymbolPinSettings(
         **dict(zip(EeSymbolPinSettings.__fields__, ee_segments[0][1:]))
     )
+    pin_settings.pos_x+=shiftX
+
     pin_dot = EeSymbolPinDot(
-        dot_x=float(ee_segments[1][0]), dot_y=float(ee_segments[1][1])
+        dot_x=float(ee_segments[1][0])+shiftX, dot_y=float(ee_segments[1][1])
     )
     pin_path = EeSymbolPinPath(path=ee_segments[2][0], color=ee_segments[2][1])
     pin_name = EeSymbolPinName(
         **dict(zip(EeSymbolPinName.__fields__, ee_segments[3][:]))
     )
+    pin_name.pos_x+=shiftX
 
     pin_dot_bis = EeSymbolPinDotBis(
         is_displayed=ee_segments[5][0],
-        circle_x=float(ee_segments[5][1]),
+        circle_x=float(ee_segments[5][1])+shiftX,
         circle_y=float(ee_segments[5][2]),
     )
     pin_clock = EeSymbolPinClock(is_displayed=ee_segments[6][0], path=ee_segments[6][1])
@@ -40,56 +54,57 @@ def add_easyeda_pin(pin_data: str, ee_symbol: EeSymbol):
     )
 
 
-def add_easyeda_rectangle(rectangle_data: str, ee_symbol: EeSymbol):
-    ee_symbol.rectangles.append(
-        EeSymbolRectangle(
-            **dict(zip(EeSymbolRectangle.__fields__, rectangle_data.split("~")[1:]))
-        )
+def add_easyeda_rectangle(rectangle_data: str, ee_symbol: EeSymbol, shiftX=0):
+    rectangle = EeSymbolRectangle(
+        **dict(zip(EeSymbolRectangle.__fields__, rectangle_data.split("~")[1:]))
     )
+    rectangle.pos_x+=shiftX
+    ee_symbol.rectangles.append(rectangle)
 
 
-def add_easyeda_polyline(polyline_data: str, ee_symbol: EeSymbol):
-    ee_symbol.polylines.append(
-        EeSymbolPolyline(
-            **dict(zip(EeSymbolPolyline.__fields__, polyline_data.split("~")[1:]))
-        )
+def add_easyeda_polyline(polyline_data: str, ee_symbol: EeSymbol, shiftX=0):
+    polyline = EeSymbolPolyline(
+        **dict(zip(EeSymbolPolyline.__fields__, polyline_data.split("~")[1:]))
     )
+    polyline.points = shift_paths_x(polyline.points, shiftX)
+    ee_symbol.polylines.append(polyline)
 
 
-def add_easyeda_polygon(polygon_data: str, ee_symbol: EeSymbol):
-    ee_symbol.polygons.append(
-        EeSymbolPolygon(
-            **dict(zip(EeSymbolPolygon.__fields__, polygon_data.split("~")[1:]))
-        )
+def add_easyeda_polygon(polygon_data: str, ee_symbol: EeSymbol, shiftX=0):
+    polygon = EeSymbolPolygon(
+        **dict(zip(EeSymbolPolygon.__fields__, polygon_data.split("~")[1:]))
     )
+    polygon.points = shift_paths_x(polygon.points, shiftX)
+    ee_symbol.polygons.append(polygon)
 
 
-def add_easyeda_path(path_data: str, ee_symbol: EeSymbol):
-    ee_symbol.paths.append(
-        EeSymbolPath(**dict(zip(EeSymbolPath.__fields__, path_data.split("~")[1:])))
+def add_easyeda_path(path_data: str, ee_symbol: EeSymbol, shiftX=0):
+    path = EeSymbolPath(**dict(zip(EeSymbolPath.__fields__, path_data.split("~")[1:])))
+    path.paths = shift_paths_x(path.paths, shiftX)
+    ee_symbol.paths.append(path)
+
+
+
+def add_easyeda_circle(circle_data: str, ee_symbol: EeSymbol, shiftX=0):
+    circle = EeSymbolCircle(
+        **dict(zip(EeSymbolCircle.__fields__, circle_data.split("~")[1:]))
     )
+    circle.center_x+=shiftX
+    ee_symbol.circles.append(circle)
 
 
-def add_easyeda_circle(circle_data: str, ee_symbol: EeSymbol):
-    ee_symbol.circles.append(
-        EeSymbolCircle(
-            **dict(zip(EeSymbolCircle.__fields__, circle_data.split("~")[1:]))
-        )
+def add_easyeda_ellipse(ellipse_data: str, ee_symbol: EeSymbol, shiftX=0):
+    ellipse = EeSymbolEllipse(
+        **dict(zip(EeSymbolEllipse.__fields__, ellipse_data.split("~")[1:]))
     )
+    ellipse.center_x+=shiftX
+    ee_symbol.ellipses.append(ellipse)
 
+def add_easyeda_arc(arc_data: str, ee_symbol: EeSymbol, shiftX=0):
+    arc=EeSymbolArc(**dict(zip(EeSymbolArc.__fields__, arc_data.split("~")[1:])))
+    arc.arcs[-1]+=shiftX
+    ee_symbol.arcs.append(arc)
 
-def add_easyeda_ellipse(ellipse_data: str, ee_symbol: EeSymbol):
-    ee_symbol.ellipses.append(
-        EeSymbolEllipse(
-            **dict(zip(EeSymbolEllipse.__fields__, ellipse_data.split("~")[1:]))
-        )
-    )
-
-
-def add_easyeda_arc(arc_data: str, ee_symbol: EeSymbol):
-    ee_symbol.arcs.append(
-        EeSymbolArc(**dict(zip(EeSymbolArc.__fields__, arc_data.split("~")[1:])))
-    )
 
 
 easyeda_handlers = {
@@ -133,12 +148,23 @@ class EasyedaSymbolImporter:
             ),
         )
 
-        for line in ee_data["dataStr"]["shape"]:
-            designator = line.split("~")[0]
-            if designator in easyeda_handlers:
-                easyeda_handlers[designator](line, new_ee_symbol)
-            else:
-                logging.warning(f"Unknow symbol designator : {designator}")
+        if len(ee_data["dataStr"]["shape"]) == 0:
+            symbol_descriptors = []
+            for symbol in ee_data["subparts"]:
+                symbol_descriptors.append(symbol["dataStr"])
+        else:
+            symbol_descriptors=ee_data["dataStr"]
+
+        if len(symbol_descriptors) > 0:
+            shiftX = 0
+            for descriptor in symbol_descriptors:
+                for line in descriptor["shape"]:
+                    designator = line.split("~")[0]
+                    if designator in easyeda_handlers:
+                        easyeda_handlers[designator](line, new_ee_symbol, shiftX=shiftX)
+                    else:
+                        logging.warning(f"Unknow symbol designator : {designator}")
+                shiftX += descriptor["BBox"]["width"] * 1.5
 
         return new_ee_symbol
 


### PR DESCRIPTION
Hi all,

first of all thank you for providing this tool in the first place it has been of great help so far. However I noticed, that the tool fails to parse certain EasyEDA parts, the symbols can not be generated. When looking closer I noticed that these parts are composed using subparts which the tool doesn't seem to support. One example is the "AO6802" on lcsc with the lcsc_id C94404.

This commit adds the support by looping through the subparts section of the EasyEDA descriptions and adding each subpart seperately to the KiCad symbol. In addition to that I had to add functionality to shift each particular element of a subpart in x direction. This allows multiple subparts to be offset in relation to each other because otherwise they would be all placed on top of each other.

The resulting symbol looks correct and seems to be working well as far as my tests go:
![image](https://github.com/user-attachments/assets/412e3058-95ee-4be8-8425-1336ead30cd2)

Thank you for considering,
Simon Lever