### PR TITLE
Prevent malformed .kicad_sym when appending symbols

### DIFF
--- a/easyeda2kicad/helpers.py
+++ b/easyeda2kicad/helpers.py
@@ -98,22 +98,22 @@ def add_component_in_symbol_lib_file(
         with open(file=lib_path, mode="a+", encoding="utf-8") as lib_file:
             lib_file.write(component_content)
     elif kicad_version == KicadVersion.v6:
-        with open(file=lib_path, mode="rb+") as lib_file:
-            lib_file.seek(-2, 2)
-            lib_file.truncate()
-            lib_file.write(component_content.encode(encoding="utf-8"))
-            lib_file.write("\n)".encode(encoding="utf-8"))
-
         with open(file=lib_path, encoding="utf-8") as lib_file:
-            new_lib_data = lib_file.read()
+            current_lib = lib_file.read()
+
+        trimmed_lib = current_lib.rstrip()
+        if trimmed_lib.endswith(")"):
+            trimmed_lib = trimmed_lib[:-1].rstrip()
+
+        component_body = component_content.lstrip("\n")
+        new_lib_data = f"{trimmed_lib}\n{component_body}\n)"
+        new_lib_data = new_lib_data.replace(
+            "(generator kicad_symbol_editor)",
+            "(generator https://github.com/uPesy/easyeda2kicad.py)",
+        )
 
         with open(file=lib_path, mode="w", encoding="utf-8") as lib_file:
-            lib_file.write(
-                new_lib_data.replace(
-                    "(generator kicad_symbol_editor)",
-                    "(generator https://github.com/uPesy/easyeda2kicad.py)",
-                )
-            )
+            lib_file.write(new_lib_data)
 
 
 def get_local_config() -> dict:


### PR DESCRIPTION
Root cause: the v6 symbol append code in helpers.py used seek(-2)/truncate() in binary mode to remove the final ) from the .kicad_sym file. On Windows (CRLF), that cuts into \r\n and leaves the library with an extra ) at the end, making the file invalid. KiCad then refuses to load the library, so symbols “don’t appear.”

Fix: changed the v6 append logic to operate in text mode instead of binary. It now reads the whole file, strips trailing whitespace, removes the final closing ), appends the new symbol, and re-adds exactly one closing ). This avoids newline/CRLF issues and keeps the s‑expression balanced.