### PR TITLE
Use Random User Agent For API Calls To Avoid Request Rejection

### DIFF
--- a/easyeda2kicad/easyeda/easyeda_api.py
+++ b/easyeda2kicad/easyeda/easyeda_api.py
@@ -4,6 +4,7 @@ import logging
 import requests
 
 from easyeda2kicad import __version__
+from fake_useragent import UserAgent
 
 API_ENDPOINT = "https://easyeda.com/api/products/{lcsc_id}/components?version=6.4.19.5"
 ENDPOINT_3D_MODEL = "https://modules.easyeda.com/3dmodel/{uuid}"
@@ -19,7 +20,7 @@ class EasyedaApi:
             "Accept-Encoding": "gzip, deflate",
             "Accept": "application/json, text/javascript, */*; q=0.01",
             "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-            "User-Agent": f"easyeda2kicad v{__version__}",
+            "User-Agent": UserAgent(platforms='desktop').random,
         }
 
     def get_info_from_easyeda_api(self, lcsc_id: str) -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pre-commit>=2.17.0
 pydantic>=2.0.0
 requests>2.0.0
+fake-useragent>=2.2.0
+pre-commit>=2.17.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 with open("README.md") as fh:
     long_description = fh.read()
 
-production_dependencies = ["pydantic>=2.0.0", "requests>2.0.0"]
+production_dependencies = ["pydantic>=2.0.0", "requests>2.0.0", "fake-useragent>=2.2.0"]
 
 development_dependencies = [
     "pre-commit>=2.17.0",


### PR DESCRIPTION
The tool became unusable since today when it would not download any part from LCSC, After closer inspection it seems that EasyEDA has blacklisted the useragent hard coded in the code (i.e. `easyeda2kicad vXYZ`).

This PR simply uses `fake_useragent` module to generate fake random useragents whilst making a request so to not get blocked.

Given the inactivity from the maintainer, I've also attached the [dist.zip](https://github.com/user-attachments/files/26464113/dist.zip) file that contains the build anyone can install, You can also clone my repository & Build it yourself.