### PR TITLE
Feature/sanitize on slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ After installation, run `easyeda2kicad` from the same KiCad Command Prompt.
 ```bash
 # For symbol + footprint + 3d model (with --full argument)
 easyeda2kicad --full --lcsc_id=C2040
+# For components not listed in public libraries (user-created)
+easyeda2kicad --full --uuid=18f70c95488944a99ceedb9505986f4e
 # For symbol + footprint + 3d model
 easyeda2kicad --symbol --footprint --3d --lcsc_id=C2040
 # For symbol + footprint
@@ -117,7 +119,8 @@ You can import several components in a single call:
 easyeda2kicad --full --lcsc_id C2040 C20197 C163691
 ```
 
-### Custom symbol fields
+If you created your own symbol, footprint or 3D model which is not listed in public libraries, you can retrieve the component by specifying the uuid argument. Find the uuid through the network inspector of your browser when you select a component in your workspace library(thus filed a request). The requested url should be something like this:
+https://easyeda.com/api/components/{uuid}?version=6.5.42&uuid={uuid}&datastrid=blah
 
 Use `--custom-field` to add extra properties to generated symbols:
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,13 @@ You can import several components in a single call:
 easyeda2kicad --full --lcsc_id C2040 C20197 C163691
 ```
 
-If you created your own symbol, footprint or 3D model which is not listed in public libraries, you can retrieve the component by specifying the uuid argument. Find the uuid through the network inspector of your browser when you select a component in your workspace library(thus filed a request). The requested url should be something like this:
+### Import User-created Components
+
+If you created your own symbol, footprint or 3D model which is not listed in public libraries, you can retrieve the component by specifying the uuid argument. Find the uuid through the network inspector of your browser when you select a component in your workspace library(thus filed a request). The requested url should be something like these:
 https://easyeda.com/api/components/{uuid}?version=6.5.42&uuid={uuid}&datastrid=blah
+https://www.easyeda.com/api/components/{uuid}?version=6.5.54&uuid={uuid}&_=blah
+
+### Custom symbol fields
 
 Use `--custom-field` to add extra properties to generated symbols:
 

--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -50,7 +50,11 @@ def get_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--lcsc_id", help="LCSC id(s)", required=True, type=str, nargs="+"
+        "--lcsc_id", help="LCSC id(s)", required=False, type=str, nargs="+"
+    )
+
+    parser.add_argument(
+        "--uuid", help="Component uuid(s)", required=False, type=str, nargs="+"
     )
 
     parser.add_argument(
@@ -140,10 +144,15 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def valid_arguments(arguments: dict[str, Any]) -> bool:
-    for lcsc_id in arguments["lcsc_id"]:
-        if not lcsc_id.startswith("C"):
-            logging.error(f"lcsc_id '{lcsc_id}' should start with C")
-            return False
+    if not arguments.get("lcsc_id") and not arguments.get("uuid"):
+        logging.error("Either --lcsc_id or --uuid must be provided")
+        return False
+
+    if arguments.get("lcsc_id"):
+        for lcsc_id in arguments["lcsc_id"]:
+            if not lcsc_id.startswith("C"):
+                logging.error(f"lcsc_id '{lcsc_id}' should start with C")
+                return False
 
     if arguments["full"]:
         arguments["symbol"], arguments["footprint"], arguments["3d"] = True, True, True
@@ -201,12 +210,14 @@ def valid_arguments(arguments: dict[str, Any]) -> bool:
 
 
 def _process_component(
-    component_id: str,
     arguments: dict[str, Any],
     api: EasyedaApi,
+    lcsc_id: str | None = None,
+    uuid: str | None = None,
 ) -> bool:
-    """Process a single LCSC component. Returns True on success, False on error."""
-    cad_data = api.get_cad_data_of_component(lcsc_id=component_id)
+    """Process a single component (LCSC or UUID). Returns True on success, False on error."""
+    component_id = lcsc_id or uuid
+    cad_data = api.get_cad_data_of_component(lcsc_id=lcsc_id, uuid=uuid)
     if not cad_data:
         logging.error(f"Failed to fetch data from EasyEDA API for part {component_id}")
         return False
@@ -354,9 +365,15 @@ def main(argv: list[str] = sys.argv[1:]) -> int:
     api = EasyedaApi(use_cache=arguments["use_cache"])
     had_errors = False
 
-    for component_id in arguments["lcsc_id"]:
-        if not _process_component(component_id, arguments, api):
-            had_errors = True
+    if arguments.get("lcsc_id"):
+        for lcsc_id in arguments["lcsc_id"]:
+            if not _process_component(arguments, api, lcsc_id=lcsc_id):
+                had_errors = True
+
+    if arguments.get("uuid"):
+        for uuid in arguments["uuid"]:
+            if not _process_component(arguments, api, uuid=uuid):
+                had_errors = True
 
     return 1 if had_errors else 0
 

--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -259,8 +259,12 @@ def _process_component(
         easyeda_footprint = EasyedaFootprintImporter(
             easyeda_cp_cad_data=cad_data
         ).get_footprint()
+        # Sanitize footprint name for filename (slashes/backslashes are invalid)
+        sanitized_fp_name = (
+            easyeda_footprint.info.name.replace("/", "_").replace("\\", "_")
+        )
         if (
-            Path(f"{output}.pretty") / f"{easyeda_footprint.info.name}.kicad_mod"
+            Path(f"{output}.pretty") / f"{sanitized_fp_name}.kicad_mod"
         ).is_file() and not arguments["overwrite"]:
             logging.error(
                 f"Footprint for {component_id} already exists. Use --overwrite to replace"
@@ -276,7 +280,7 @@ def _process_component(
             )
         else:
             model_3d_path = Path(f"{output}.3dshapes").as_posix()
-        footprint_filename = f"{easyeda_footprint.info.name}.kicad_mod"
+        footprint_filename = f"{sanitized_fp_name}.kicad_mod"
         ExporterFootprintKicad(footprint=easyeda_footprint).export(
             footprint_full_path=str(footprint_path / footprint_filename),
             model_3d_path=model_3d_path,

--- a/easyeda2kicad/easyeda/easyeda_api.py
+++ b/easyeda2kicad/easyeda/easyeda_api.py
@@ -36,6 +36,9 @@ API_ENDPOINT = "https://easyeda.com/api/products/{lcsc_id}/components"
 ENDPOINT_SVG = "https://easyeda.com/api/products/{lcsc_id}/svgs"
 ENDPOINT_3D_MODEL = "https://modules.easyeda.com/3dmodel/{uuid}"
 ENDPOINT_3D_MODEL_STEP = "https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y/{uuid}"
+API_PRIVATE_COMPONENTS = (
+    "https://easyeda.com/api/components/{uuid}?version=6.5.42&uuid={uuid}"
+)
 
 # EasyEDA Pro API (v2) endpoints
 API_BASE_V2 = "https://pro.easyeda.com"
@@ -161,9 +164,15 @@ class EasyedaApi:
         logging.debug("Using system default SSL certificates")
         return context
 
-    def get_info_from_easyeda_api(self, lcsc_id: str) -> dict[str, Any]:
+    def get_info_from_easyeda_api(
+        self, lcsc_id: str | None = None, uuid: str | None = None
+    ) -> dict[str, Any]:
+        identifier = lcsc_id or uuid
+        if not identifier:
+            return {}
+
         # Try to read from cache first
-        cache_path = self._get_cache_path(lcsc_id, "json")
+        cache_path = self._get_cache_path(identifier, "json")
         cached_data = self._read_from_cache(cache_path, binary=False)
         if cached_data is not None:
             try:
@@ -171,13 +180,16 @@ class EasyedaApi:
                 return cached
             except json.JSONDecodeError:
                 logging.warning(
-                    f"Invalid cached JSON for {lcsc_id}, fetching fresh data"
+                    f"Invalid cached JSON for {identifier}, fetching fresh data"
                 )
 
         try:
-            req = urllib.request.Request(  # noqa: S310
-                url=API_ENDPOINT.format(lcsc_id=lcsc_id), headers=self.headers
-            )
+            if lcsc_id:
+                url = API_ENDPOINT.format(lcsc_id=lcsc_id)
+            else:
+                url = API_PRIVATE_COMPONENTS.format(uuid=uuid)
+
+            req = urllib.request.Request(url=url, headers=self.headers)  # noqa: S310
             with urllib.request.urlopen(  # noqa: S310
                 req, timeout=30, context=self.ssl_context
             ) as response:
@@ -200,8 +212,10 @@ class EasyedaApi:
             logging.error(f"API request failed: {e}")
             return {}
 
-    def get_cad_data_of_component(self, lcsc_id: str) -> dict[str, Any]:
-        cp_cad_info = self.get_info_from_easyeda_api(lcsc_id=lcsc_id)
+    def get_cad_data_of_component(
+        self, lcsc_id: str | None = None, uuid: str | None = None
+    ) -> dict[str, Any]:
+        cp_cad_info = self.get_info_from_easyeda_api(lcsc_id=lcsc_id, uuid=uuid)
         if not cp_cad_info:
             return {}
         result: dict[str, Any] = cp_cad_info["result"]

--- a/easyeda2kicad/easyeda/easyeda_importer.py
+++ b/easyeda2kicad/easyeda/easyeda_importer.py
@@ -439,7 +439,11 @@ class EasyedaSymbolImporter:
             origin_y = _safe_float(head_data.get("y")) or 0.0
 
         lcsc_dict = ee_data.get("lcsc") or {}
-        lcsc_number = lcsc_dict.get("number", "")
+        lcsc_number = (
+            lcsc_dict.get("number", "")
+            or ee_data_info.get("Supplier Part", "")
+            or ee_data_info.get("LCSC Part", "")
+        )
 
         new_ee_symbol = EeSymbol(
             info=EeSymbolInfo(
@@ -451,9 +455,11 @@ class EasyedaSymbolImporter:
                 mpn=ee_data_info.get("Manufacturer Part", "")
                 or ee_data_info.get("BOM_Manufacturer Part", ""),
                 datasheet=lcsc_dict.get("url", "")
+                or ee_data_info.get("link", "")
+                or ee_data_info.get("datasheet", "")
                 or (
                     f"https://www.lcsc.com/datasheet/{lcsc_number}.pdf"
-                    if lcsc_number
+                    if lcsc_number and lcsc_number.startswith("C")
                     else ""
                 ),
                 lcsc_id=lcsc_number,


### PR DESCRIPTION
- if there are slashes or backslashes in the part name/component name, writing files would cause errors. Now correct it.

Notice: this pull requst can **ONLY** be done/processed/merged when the previous pull request from [tingjhenjiang:feature/user-created-component-retrieval to uPesy:dev](https://github.com/uPesy/easyeda2kicad.py/pull/198) is completed.