### PR TITLE
Improve LCSC/JLC description handling for symbol metadata only

### DIFF
--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -213,11 +213,21 @@ def _process_component(
 
     output = arguments["output"]
 
+    # Always use product-detail page for description scraping.
+    # cad_data['lcsc']['url'] may point to datasheet PDF and is unsuitable.
+    lcsc_url = f"https://www.lcsc.com/product-detail/{component_id}.html"
+    # Prefer structured spec description from JLCPCB attributes, then LCSC page parsing.
+    lcsc_page_description = api.get_jlcpcb_specs_description(component_id) or (
+        api.get_product_description(lcsc_url) or ""
+    )
+
     if arguments["symbol"]:
         # ---------------- SYMBOL ----------------
         easyeda_symbol: EeSymbol = EasyedaSymbolImporter(
             easyeda_cp_cad_data=cad_data
         ).get_symbol()
+        if lcsc_page_description:
+            easyeda_symbol.info.description = lcsc_page_description
         lib_path = f"{output}.kicad_sym"
         exporter = ExporterSymbolKicad(
             symbol=easyeda_symbol,

--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -258,6 +258,8 @@ def _process_component(
         easyeda_footprint = EasyedaFootprintImporter(
             easyeda_cp_cad_data=cad_data
         ).get_footprint()
+        # Keep footprint description untouched by LCSC/JLC enrichment request: no descr field.
+        easyeda_footprint.info.description = ""
         if (
             Path(f"{output}.pretty") / f"{easyeda_footprint.info.name}.kicad_mod"
         ).is_file() and not arguments["overwrite"]:

--- a/easyeda2kicad/easyeda/easyeda_api.py
+++ b/easyeda2kicad/easyeda/easyeda_api.py
@@ -11,6 +11,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from html import unescape
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -503,3 +504,232 @@ class EasyedaApi:
                 if isinstance(value, str) and value.startswith("http"):
                     return value
         return None
+
+    def get_product_description(self, lcsc_url: str) -> str | None:
+        """Fetch a product description/title from an LCSC product page.
+
+        Extraction order:
+        1. ``meta[name=description]`` content
+        2. JSON-LD ``description``
+        3. ``og:title`` content
+        4. HTML ``<title>`` text
+
+        Only fetches from lcsc.com hosts. Returns None if unavailable.
+        """
+        if not lcsc_url:
+            return None
+        parsed = urllib.parse.urlparse(lcsc_url)
+        if parsed.hostname not in ("lcsc.com", "www.lcsc.com"):
+            logging.warning(
+                f"get_product_description: unexpected host {parsed.hostname!r}, skipping"
+            )
+            return None
+
+        try:
+            req = urllib.request.Request(  # noqa: S310
+                url=lcsc_url,
+                headers={
+                    **self.headers,
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                },
+            )
+            with urllib.request.urlopen(  # noqa: S310
+                req, timeout=10, context=self.ssl_context
+            ) as response:
+                html = self._decode_response(response.read())
+        except (urllib.error.URLError, OSError) as e:
+            logging.error(f"Failed to fetch LCSC product page for description: {e}")
+            return None
+
+        # 0) Prefer structured JSON-LD specs when available (more useful than marketing meta text)
+        structured = self._extract_structured_product_description_from_json_ld(html)
+        if structured:
+            return structured
+
+        # 0b) Fallback: parse HTML spec rows rendered on product page
+        html_specs = self._extract_structured_product_description_from_html_specs(html)
+        if html_specs:
+            return html_specs
+
+        meta_desc = re.search(
+            r'<meta[^>]+name=["\']description["\'][^>]+content=["\']([^"\']+)["\']',
+            html,
+            re.IGNORECASE,
+        ) or re.search(
+            r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+name=["\']description["\']',
+            html,
+            re.IGNORECASE,
+        )
+        if meta_desc:
+            return meta_desc.group(1).strip()
+
+        for blob in re.findall(
+            r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+            html,
+            re.DOTALL,
+        ):
+            try:
+                data = json.loads(blob)
+            except json.JSONDecodeError:
+                continue
+
+            candidates = data if isinstance(data, list) else [data]
+            for entry in candidates:
+                if isinstance(entry, dict):
+                    desc = entry.get("description")
+                    if isinstance(desc, str) and desc.strip():
+                        return desc.strip()
+
+        og_title = re.search(
+            r'<meta[^>]+(?:name|property)=["\']og:title["\'][^>]+content=["\']([^"\']+)["\']',
+            html,
+            re.IGNORECASE,
+        ) or re.search(
+            r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+(?:name|property)=["\']og:title["\']',
+            html,
+            re.IGNORECASE,
+        )
+        if og_title:
+            return og_title.group(1).strip()
+
+        title = re.search(r"<title>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+        if title:
+            return re.sub(r"\s+", " ", title.group(1)).strip()
+
+        return None
+
+    def get_jlcpcb_specs_description(self, lcsc_id: str) -> str | None:
+        """Build a concise description from JLCPCB component attributes for an LCSC part."""
+        if not lcsc_id:
+            return None
+        result = self.search_jlcpcb_components(keyword=lcsc_id, page=1, page_size=10)
+        items = result.get("results") or []
+        match = next((i for i in items if i.get("lcsc") == lcsc_id), None)
+        if not isinstance(match, dict):
+            return None
+
+        name = (match.get("name") or "").strip()
+        brand = (match.get("brand") or "").strip()
+        package = (match.get("package") or "").strip()
+        attrs = match.get("attributes") or []
+
+        parts: list[str] = []
+        if brand:
+            parts.append(f"Manufacturer: {brand}")
+        if package:
+            parts.append(f"Package: {package}")
+
+        for a in attrs:
+            if not isinstance(a, dict):
+                continue
+            k = a.get("name")
+            v = a.get("value")
+            if isinstance(k, str) and isinstance(v, str) and k and v and v != "-":
+                parts.append(f"{k}: {v}")
+
+        if not parts:
+            return None
+        return (f"{name} | " if name else "") + "; ".join(parts)
+
+    def _extract_structured_product_description_from_json_ld(
+        self, html: str
+    ) -> str | None:
+        """Build a compact, spec-rich description from JSON-LD Product data."""
+        for blob in re.findall(
+            r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+            html,
+            re.DOTALL,
+        ):
+            try:
+                data = json.loads(blob)
+            except json.JSONDecodeError:
+                continue
+
+            nodes = data if isinstance(data, list) else [data]
+            for node in nodes:
+                if not isinstance(node, dict):
+                    continue
+
+                node_type = node.get("@type")
+                if node_type not in ("Product", ["Product"], "Thing"):
+                    continue
+
+                name = node.get("name") if isinstance(node.get("name"), str) else ""
+                specs_parts: list[str] = []
+                additional = node.get("additionalProperty")
+                if isinstance(additional, list):
+                    for prop in additional:
+                        if not isinstance(prop, dict):
+                            continue
+                        key = prop.get("name")
+                        value = prop.get("value")
+                        if isinstance(key, str) and isinstance(value, str):
+                            key_clean = unescape(key).strip()
+                            val_clean = unescape(value).strip()
+                            if key_clean and val_clean and val_clean != "-":
+                                specs_parts.append(f"{key_clean}: {val_clean}")
+
+                if specs_parts:
+                    if name:
+                        return f"{name} | " + "; ".join(specs_parts)
+                    return "; ".join(specs_parts)
+
+        return None
+
+    def _extract_structured_product_description_from_html_specs(
+        self, html: str
+    ) -> str | None:
+        """Extract product spec rows from LCSC HTML and render concise description."""
+        # Try to capture common <tr><td>Key</td><td>Value</td></tr> style rows.
+        row_pattern = re.compile(
+            r"<tr[^>]*>\s*<t[dh][^>]*>(.*?)</t[dh]>\s*<t[dh][^>]*>(.*?)</t[dh]>\s*</tr>",
+            re.IGNORECASE | re.DOTALL,
+        )
+        rows = row_pattern.findall(html)
+        if not rows:
+            return None
+
+        def _clean(text: str) -> str:
+            text_no_tags = re.sub(r"<[^>]+>", " ", text)
+            return re.sub(r"\s+", " ", unescape(text_no_tags)).strip()
+
+        specs: list[tuple[str, str]] = []
+        for raw_key, raw_val in rows:
+            key = _clean(raw_key)
+            val = _clean(raw_val)
+            if not key or not val or val == "-":
+                continue
+            specs.append((key, val))
+
+        if not specs:
+            return None
+
+        preferred_order = [
+            "Manufacturer",
+            "Package",
+            "Gain",
+            "Bandwidth",
+            "Slew Rate",
+            "Single Supply",
+            "Differential Voltage",
+            "Common Mode Rejection Ratio (CMRR)",
+            "Operating Temperature",
+        ]
+        specs_map = {k: v for k, v in specs}
+        picked: list[str] = []
+        for k in preferred_order:
+            if k in specs_map:
+                picked.append(f"{k}: {specs_map[k]}")
+
+        # If none of preferred fields found, use first rows as generic fallback.
+        if not picked:
+            picked = [f"{k}: {v}" for k, v in specs[:10]]
+
+        # Prefix with product name from title if available.
+        title = re.search(r"<title>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+        if title:
+            name = re.sub(r"\s+", " ", _clean(title.group(1))).split("-")[0].strip()
+            if name:
+                return f"{name} | " + "; ".join(picked)
+
+        return "; ".join(picked)

--- a/tests/test_easyeda_api.py
+++ b/tests/test_easyeda_api.py
@@ -602,6 +602,96 @@ class TestGetProductImageUrl:
         assert api.get_product_image_url("https://www.lcsc.com/product/C1.html") is None
 
 
+class TestGetProductDescription:
+    def test_json_ld_additional_property_specs_preferred(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        api = EasyedaApi(use_cache=False)
+        ld = json.dumps(
+            {
+                "@context": "https://schema.org",
+                "@type": "Product",
+                "name": "INA296A3IDR",
+                "additionalProperty": [
+                    {"name": "Gain", "value": "50V/V"},
+                    {"name": "Bandwidth", "value": "1.1MHz"},
+                    {"name": "Package", "value": "SOIC-8"},
+                ],
+            }
+        )
+        html = (
+            b"<html><head>"
+            b'<meta name="description" content="generic marketing text"/>'
+            + f'<script type="application/ld+json">{ld}</script>'.encode()
+            + b"</head></html>"
+        )
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda *a, **kw: _fake_response(html)
+        )
+        result = api.get_product_description(
+            "https://www.lcsc.com/product-detail/C1591.html"
+        )
+        assert result == (
+            "INA296A3IDR | Gain: 50V/V; Bandwidth: 1.1MHz; Package: SOIC-8"
+        )
+
+    def test_meta_description_extracted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        api = EasyedaApi(use_cache=False)
+        html = (
+            b"<html><head>"
+            b'<meta name="description" content="High precision resistor 1k 1%"/>'
+            b"</head></html>"
+        )
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda *a, **kw: _fake_response(html)
+        )
+        result = api.get_product_description(
+            "https://www.lcsc.com/product-detail/C1591.html"
+        )
+        assert result == "High precision resistor 1k 1%"
+
+    def test_json_ld_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = EasyedaApi(use_cache=False)
+        ld = json.dumps(
+            {
+                "@type": "Product",
+                "description": "MLCC capacitor 100nF 50V X7R",
+            }
+        )
+        html = (
+            f'<html><head><script type="application/ld+json">{ld}</script>'
+            f"</head></html>"
+        ).encode()
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda *a, **kw: _fake_response(html)
+        )
+        result = api.get_product_description(
+            "https://www.lcsc.com/product-detail/C1591.html"
+        )
+        assert result == "MLCC capacitor 100nF 50V X7R"
+
+    def test_og_title_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = EasyedaApi(use_cache=False)
+        html = (
+            b"<html><head>"
+            b'<meta property="og:title" content="STM32 MCU LQFP48"/>'
+            b"</head></html>"
+        )
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda *a, **kw: _fake_response(html)
+        )
+        result = api.get_product_description(
+            "https://www.lcsc.com/product-detail/C1591.html"
+        )
+        assert result == "STM32 MCU LQFP48"
+
+    def test_non_lcsc_host_returns_none(self) -> None:
+        api = EasyedaApi(use_cache=False)
+        assert api.get_product_description("https://evil.com/page") is None
+
+
 # ---------------------------------------------------------------------------
 # _get_v2_json / search_v2_component_uuids_by_lcsc — monkeypatched
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### **Summary**
This PR improves description enrichment by using structured JLCPCB/LCSC spec data for symbol metadata, while keeping footprint description unchanged.

### **Changes**
Add a structured description builder from JLCPCB component attributes (by LCSC ID).
Prefer structured JLCPCB specs; fallback to LCSC product-page parsing.
Apply enriched description to symbol ki_description.
Do not inject/override footprint descr.
Keep generation flow working for symbol/footprint/3D outputs.
### **Why**
Symbol metadata benefits from richer searchable technical fields.
Footprint files should stay clean and avoid long marketing/spec strings in descr.
### **Validation**
Ran:
`python -m pytest tests/test_easyeda_api.py -q`
Generated and verified:

- C30630184
- C970390

Confirmed:

- symbol contains enriched ki_description
- footprint does not get forced description injection

**Backward ### compatibility**
No breaking CLI changes.
Behavior only changes in description selection/binding.