### PR TITLE
feat: sanitize component names and add --uuid flag for user-created components

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,5 +26,4 @@ repos:
     hooks:
     -   id: mypy
         args: [--strict]
-        files: \.py$
-        additional_dependencies: [pytest>=8.0]
+        files: ^easyeda2kicad/.*\.py$

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# easyeda2kicad v1.0.0
+# easyeda2kicad
 
-[![PyPI version](https://badge.fury.io/py/easyeda2kicad.svg)](https://badge.fury.io/py/easyeda2kicad)
-[![License](https://img.shields.io/github/license/upesy/easyeda2kicad.py.svg)](https://pypi.org/project/isort/)
+[![PyPI version](https://img.shields.io/pypi/v/easyeda2kicad.svg)](https://pypi.org/project/easyeda2kicad/)
+[![License](https://img.shields.io/github/license/upesy/easyeda2kicad.py.svg)](https://github.com/uPesy/easyeda2kicad.py/blob/master/LICENSE)
 [![Downloads](https://pepy.tech/badge/easyeda2kicad)](https://pepy.tech/project/easyeda2kicad)
 ![Python versions](https://img.shields.io/pypi/pyversions/easyeda2kicad.svg)
 [![Git hook: pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
@@ -20,13 +20,7 @@ A Python script that converts any electronic components from [EasyEDA](https://e
 
 ## 💾 Installation
 
-If you have already Python installed you can run directly in the common terminal.<br>
-If not, you can use the Python executable included with Kicad by using the KiCad Command Prompt.
-<div align="left">
-  <img src="/ressources/kicad_command_prompt_install.png" width="800">
-</div>
-
-Then run this command to install easyeda2kicad
+If you have Python installed on your system:
 
 ```bash
 pip install easyeda2kicad
@@ -34,45 +28,37 @@ pip install easyeda2kicad
 
 ### Installation using the KiCad Command Prompt
 
-KiCad ships with its own Python interpreter. If you don't have a separate Python installation, you can use the **KiCad Command Prompt** to install easyeda2kicad into KiCad's Python environment.
+KiCad ships with its own Python interpreter. If you don't have a separate Python installation, you can use KiCad's bundled Python to install easyeda2kicad.
 
-**Windows:** Open the KiCad Command Prompt via *Start Menu → KiCad → KiCad Command Prompt*, then run:
+**Windows:** KiCad bundles its own Python. Search for *KiCad Command Prompt* in the Start Menu, then run `pip install easyeda2kicad`. Note: KiCad's Scripts folder is not on PATH, so use `python -m easyeda2kicad` to run the tool from the KiCad Command Prompt.
 
-```bash
-pip install easyeda2kicad
-```
+**Linux:** On most distributions, KiCad uses the system Python — `pip install easyeda2kicad` works directly.
 
-**Linux / macOS:** KiCad's Python is typically not on the system PATH. Use the full path to KiCad's pip, for example:
+**macOS:** KiCad bundles its own Python. Install into it with:
 
 ```bash
-/usr/lib/kicad/lib/python3/dist-packages/../../../bin/python3 -m pip install easyeda2kicad
+/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3 -m pip install easyeda2kicad
 ```
 
-Or locate it with:
+> **Tip:** In the PCB Editor, open *Tools → Scripting Console* and run `import sys; print(sys.executable)` to get KiCad's Python path. Then run that path with `-m pip install easyeda2kicad` in a terminal.
 
-```bash
-find /usr -name "pip*" | grep kicad
-```
-
-After installation, run `easyeda2kicad` from the same KiCad Command Prompt.
+After installation, run `easyeda2kicad` from the same terminal or KiCad Command Prompt.
 
 ## 💻 Usage
 
 ```bash
-# For symbol + footprint + 3d model (with --full argument)
+# Symbol + footprint + 3D model
 easyeda2kicad --full --lcsc_id=C2040
-# For symbol + footprint + 3d model
-easyeda2kicad --symbol --footprint --3d --lcsc_id=C2040
-# For symbol + footprint
-easyeda2kicad --symbol --footprint --lcsc_id=C2040
-# For symbol only
+# Individual parts
 easyeda2kicad --symbol --lcsc_id=C2040
-# For footprint only
 easyeda2kicad --footprint --lcsc_id=C2040
-# For 3d model only
 easyeda2kicad --3d --lcsc_id=C2040
-# Import multiple components at once
+# Multiple components at once
 easyeda2kicad --full --lcsc_id C2040 C20197 C163691
+# Custom output path
+easyeda2kicad --full --lcsc_id=C2040 --output ~/libs/my_lib
+# SVG preview (no KiCad conversion)
+easyeda2kicad --svg --lcsc_id=C2040 --output ~/libs/my_lib
 ```
 
 By default, all libraries are saved in `~/Documents/Kicad/easyeda2kicad/` (Linux/macOS) or `C:/Users/your_name/Documents/Kicad/easyeda2kicad/` (Windows), with:
@@ -127,8 +113,7 @@ easyeda2kicad --symbol --lcsc_id=C2040 --custom-field "Manufacturer:Texas Instru
 
 Malformed values (missing `:`) fail fast. Duplicate keys use the last value.
 
-If EasyEDA does not provide a datasheet URL for a symbol, easyeda2kicad falls
-back to `https://www.lcsc.com/datasheet/<LCSC-ID>.pdf`.
+If EasyEDA does not provide a datasheet URL for a symbol, easyeda2kicad falls back to `https://www.lcsc.com/datasheet/<LCSC-ID>.pdf`.
 
 ### Using a proxy server
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ For detailed information about the EasyEDA data format and how commands are pars
 - **[CMD_SYMBOL.md](docs/CMD_SYMBOL.md)** - Compact reference for all symbol commands (P, R, C, E, A, PL, PG, PT) with field definitions and real examples
 - **[CMD_3D_MODEL.md](docs/CMD_3D_MODEL.md)** - Reference for 3D model download, OBJ/STEP formats, and WRL conversion
 
+## GUIs & related projects
+
+- [Import-LIB-KiCad-Plugin](https://github.com/Steffen-W/Import-LIB-KiCad-Plugin) — KiCad plugin with GUI to import components directly within KiCad
+- [EasyEDA2Kicad-GUI](https://github.com/ProjectProcrastinator/EasyEDA2Kicad-GUI) — cross-platform desktop GUI wrapper (Electron)
+- [kicad_jlcimport](https://github.com/jvanderberg/kicad_jlcimport) — independent JLCPCB component importer for KiCad
+- [easyEdaDownloader](https://github.com/JoeShade/easyEdaDownloader) — Chrome extension to download EasyEDA components (JavaScript)
+- [easyeda2eagle](https://github.com/nschurando/easyeda2eagle) — EasyEDA to Eagle converter, based on this project
+
 ## 🔥 Important Notes
 
 ### WARRANTY

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![Downloads](https://pepy.tech/badge/easyeda2kicad)](https://pepy.tech/project/easyeda2kicad)
 ![Python versions](https://img.shields.io/pypi/pyversions/easyeda2kicad.svg)
 [![Git hook: pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-[![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 A Python script that converts any electronic components from [EasyEDA](https://easyeda.com/) or [LCSC](https://www.lcsc.com/) to a KiCad library including **3D model** in color. This tool will speed up your PCB design workflow especially when using [JLCPCB SMT assembly services](https://jlcpcb.com/caa). **It supports KiCad v6 and newer.**
 

--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -50,7 +50,15 @@ def get_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--lcsc_id", help="LCSC id(s)", required=True, type=str, nargs="+"
+        "--lcsc_id", help="LCSC id(s)", required=False, type=str, nargs="+"
+    )
+
+    parser.add_argument(
+        "--uuid",
+        help="Component uuid(s) for user-created parts",
+        required=False,
+        type=str,
+        nargs="+",
     )
 
     parser.add_argument(
@@ -140,10 +148,15 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def valid_arguments(arguments: dict[str, Any]) -> bool:
-    for lcsc_id in arguments["lcsc_id"]:
-        if not lcsc_id.startswith("C"):
-            logging.error(f"lcsc_id '{lcsc_id}' should start with C")
-            return False
+    if not arguments.get("lcsc_id") and not arguments.get("uuid"):
+        logging.error("Either --lcsc_id or --uuid must be provided")
+        return False
+
+    if arguments.get("lcsc_id"):
+        for lcsc_id in arguments["lcsc_id"]:
+            if not lcsc_id.startswith("C"):
+                logging.error(f"lcsc_id '{lcsc_id}' should start with C")
+                return False
 
     if arguments["full"]:
         arguments["symbol"], arguments["footprint"], arguments["3d"] = True, True, True
@@ -201,12 +214,14 @@ def valid_arguments(arguments: dict[str, Any]) -> bool:
 
 
 def _process_component(
-    component_id: str,
     arguments: dict[str, Any],
     api: EasyedaApi,
+    lcsc_id: str | None = None,
+    uuid: str | None = None,
 ) -> bool:
-    """Process a single LCSC component. Returns True on success, False on error."""
-    cad_data = api.get_cad_data_of_component(lcsc_id=component_id)
+    """Process a single component. Returns True on success, False on error."""
+    component_id = lcsc_id or uuid
+    cad_data = api.get_cad_data_of_component(lcsc_id=lcsc_id, uuid=uuid)
     if not cad_data:
         logging.error(f"Failed to fetch data from EasyEDA API for part {component_id}")
         return False
@@ -354,9 +369,15 @@ def main(argv: list[str] = sys.argv[1:]) -> int:
     api = EasyedaApi(use_cache=arguments["use_cache"])
     had_errors = False
 
-    for component_id in arguments["lcsc_id"]:
-        if not _process_component(component_id, arguments, api):
-            had_errors = True
+    if arguments.get("lcsc_id"):
+        for lcsc_id in arguments["lcsc_id"]:
+            if not _process_component(arguments, api, lcsc_id=lcsc_id):
+                had_errors = True
+
+    if arguments.get("uuid"):
+        for uuid in arguments["uuid"]:
+            if not _process_component(arguments, api, uuid=uuid):
+                had_errors = True
 
     return 1 if had_errors else 0
 

--- a/easyeda2kicad/easyeda/easyeda_api.py
+++ b/easyeda2kicad/easyeda/easyeda_api.py
@@ -33,6 +33,7 @@ except ImportError:
 
 API_BASE_LEGACY = "https://easyeda.com"
 API_ENDPOINT = "https://easyeda.com/api/products/{lcsc_id}/components"
+API_ENDPOINT_BY_UUID = "https://easyeda.com/api/components/{uuid}"
 ENDPOINT_SVG = "https://easyeda.com/api/products/{lcsc_id}/svgs"
 ENDPOINT_3D_MODEL = "https://modules.easyeda.com/3dmodel/{uuid}"
 ENDPOINT_3D_MODEL_STEP = "https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y/{uuid}"
@@ -161,9 +162,14 @@ class EasyedaApi:
         logging.debug("Using system default SSL certificates")
         return context
 
-    def get_info_from_easyeda_api(self, lcsc_id: str) -> dict[str, Any]:
-        # Try to read from cache first
-        cache_path = self._get_cache_path(lcsc_id, "json")
+    def get_info_from_easyeda_api(
+        self, lcsc_id: str | None = None, uuid: str | None = None
+    ) -> dict[str, Any]:
+        identifier = lcsc_id or uuid
+        if not identifier:
+            return {}
+
+        cache_path = self._get_cache_path(identifier, "json")
         cached_data = self._read_from_cache(cache_path, binary=False)
         if cached_data is not None:
             try:
@@ -171,13 +177,15 @@ class EasyedaApi:
                 return cached
             except json.JSONDecodeError:
                 logging.warning(
-                    f"Invalid cached JSON for {lcsc_id}, fetching fresh data"
+                    f"Invalid cached JSON for {identifier}, fetching fresh data"
                 )
 
         try:
-            req = urllib.request.Request(  # noqa: S310
-                url=API_ENDPOINT.format(lcsc_id=lcsc_id), headers=self.headers
-            )
+            if lcsc_id:
+                url = API_ENDPOINT.format(lcsc_id=lcsc_id)
+            else:
+                url = API_ENDPOINT_BY_UUID.format(uuid=uuid)
+            req = urllib.request.Request(url=url, headers=self.headers)  # noqa: S310
             with urllib.request.urlopen(  # noqa: S310
                 req, timeout=30, context=self.ssl_context
             ) as response:
@@ -192,7 +200,6 @@ class EasyedaApi:
                 logging.debug(f"{api_response}")
                 return {}
 
-            # Write to cache
             self._write_to_cache(cache_path, data, binary=False)
 
             return api_response
@@ -200,8 +207,10 @@ class EasyedaApi:
             logging.error(f"API request failed: {e}")
             return {}
 
-    def get_cad_data_of_component(self, lcsc_id: str) -> dict[str, Any]:
-        cp_cad_info = self.get_info_from_easyeda_api(lcsc_id=lcsc_id)
+    def get_cad_data_of_component(
+        self, lcsc_id: str | None = None, uuid: str | None = None
+    ) -> dict[str, Any]:
+        cp_cad_info = self.get_info_from_easyeda_api(lcsc_id=lcsc_id, uuid=uuid)
         if not cp_cad_info:
             return {}
         result: dict[str, Any] = cp_cad_info["result"]

--- a/easyeda2kicad/easyeda/easyeda_importer.py
+++ b/easyeda2kicad/easyeda/easyeda_importer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import fields
 from typing import Any, Union, get_args, get_origin, get_type_hints
 
@@ -51,6 +52,15 @@ from .parameters_easyeda import (
     EeSymbolRectangle,
     EeFootprint,
 )
+
+
+# Characters illegal in KiCad LIB_IDs (lib_id.cpp: isLegalChar) or on the filesystem.
+# '/' is legal in KiCad names but is a path separator on Linux/Mac.
+_ILLEGAL_FOOTPRINT_NAME_RE = re.compile(r'[/\\:<>"\t\n\r]')
+
+
+def _sanitize_footprint_name(name: str) -> str:
+    return _ILLEGAL_FOOTPRINT_NAME_RE.sub("_", name)
 
 
 def _sanitize_component_name(name: str) -> str:
@@ -524,7 +534,7 @@ class EasyedaFootprintImporter:
     ) -> EeFootprint:
         new_ee_footprint = EeFootprint(
             info=EeFootprintInfo(
-                name=ee_data_info["package"],
+                name=_sanitize_footprint_name(ee_data_info["package"]),
                 fp_type="smd" if is_smd else "tht",
                 model_3d_name=ee_data_info.get("3DModel", ""),
                 lcsc_id=lcsc_id,

--- a/easyeda2kicad/easyeda/easyeda_importer.py
+++ b/easyeda2kicad/easyeda/easyeda_importer.py
@@ -449,7 +449,21 @@ class EasyedaSymbolImporter:
             origin_y = _safe_float(head_data.get("y")) or 0.0
 
         lcsc_dict = ee_data.get("lcsc") or {}
-        lcsc_number = lcsc_dict.get("number", "")
+        lcsc_number = (
+            lcsc_dict.get("number", "")
+            or ee_data_info.get("Supplier Part", "")
+            or ee_data_info.get("LCSC Part", "")
+        )
+        datasheet = (
+            lcsc_dict.get("url", "")
+            or ee_data_info.get("link", "")
+            or ee_data_info.get("datasheet", "")
+            or (
+                f"https://www.lcsc.com/datasheet/{lcsc_number}.pdf"
+                if lcsc_number and lcsc_number.startswith("C")
+                else ""
+            )
+        )
 
         new_ee_symbol = EeSymbol(
             info=EeSymbolInfo(
@@ -460,12 +474,7 @@ class EasyedaSymbolImporter:
                 or ee_data_info.get("BOM_Manufacturer", ""),
                 mpn=ee_data_info.get("Manufacturer Part", "")
                 or ee_data_info.get("BOM_Manufacturer Part", ""),
-                datasheet=lcsc_dict.get("url", "")
-                or (
-                    f"https://www.lcsc.com/datasheet/{lcsc_number}.pdf"
-                    if lcsc_number
-                    else ""
-                ),
+                datasheet=datasheet,
                 lcsc_id=lcsc_number,
                 keywords=" ".join(ee_data.get("tags", [])),
                 description=ee_data.get("description", ""),
@@ -507,11 +516,16 @@ class EasyedaFootprintImporter:
                 and "-TH_" not in self.input["packageDetail"]["title"]
             )
 
+        _lcsc_id = (
+            self.input.get("lcsc", {}).get("number", "")
+            or _c_para.get("Supplier Part", "")
+            or _c_para.get("LCSC Part", "")
+        )
         self.output = self.extract_easyeda_data(
             ee_data_str=self.input["packageDetail"]["dataStr"],
             ee_data_info=_c_para,
             is_smd=_is_smd,
-            lcsc_id=self.input.get("lcsc", {}).get("number", ""),
+            lcsc_id=_lcsc_id,
             manufacturer=_c_para.get("Manufacturer", "")
             or _c_para.get("BOM_Manufacturer", ""),
             mpn=_c_para.get("Manufacturer Part", "")

--- a/easyeda2kicad/kicad/parameters_kicad_symbol.py
+++ b/easyeda2kicad/kicad/parameters_kicad_symbol.py
@@ -79,8 +79,12 @@ class KiSymbolDefaults(Enum):
     FIELD_OFFSET_INCREMENT = 2.54
 
 
+# Characters illegal in KiCad LIB_IDs (lib_id.cpp: isLegalChar).
+_ILLEGAL_SYMBOL_ID_RE = re.compile(r'[/\\:<>"\t\n\r]')
+
+
 def sanitize_fields(name: str) -> str:
-    return name.replace(" ", "").replace("/", "_").replace(":", "_")
+    return _ILLEGAL_SYMBOL_ID_RE.sub("_", name).replace(" ", "")
 
 
 def apply_text_style(text: str) -> str:

--- a/tests/test_footprint_writer.py
+++ b/tests/test_footprint_writer.py
@@ -4,6 +4,7 @@ import math
 
 import pytest
 
+from easyeda2kicad.easyeda.easyeda_importer import _sanitize_footprint_name
 from easyeda2kicad.kicad.export_kicad_footprint import (
     angle_to_ki,
     compute_arc,
@@ -147,3 +148,34 @@ class TestComputeArc:
         d_start = math.sqrt((1 - cx) ** 2 + (0 - cy) ** 2)
         d_end = math.sqrt((1 - cx) ** 2 + (0 - cy) ** 2)
         assert abs(d_start - d_end) < TOL
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_footprint_name
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeFootprintName:
+    def test_clean_name_unchanged(self) -> None:
+        assert _sanitize_footprint_name("SOT-23") == "SOT-23"
+
+    def test_forward_slash_replaced(self) -> None:
+        assert _sanitize_footprint_name("USB/UART") == "USB_UART"
+
+    def test_backslash_replaced(self) -> None:
+        assert _sanitize_footprint_name("A\\B") == "A_B"
+
+    def test_colon_replaced(self) -> None:
+        assert _sanitize_footprint_name("lib:name") == "lib_name"
+
+    def test_angle_brackets_replaced(self) -> None:
+        assert _sanitize_footprint_name("A<->B") == "A_-_B"
+
+    def test_quote_replaced(self) -> None:
+        assert _sanitize_footprint_name('say"hi"') == "say_hi_"
+
+    def test_spaces_preserved(self) -> None:
+        assert _sanitize_footprint_name("SOT 23") == "SOT 23"
+
+    def test_mixed_illegal_chars(self) -> None:
+        assert _sanitize_footprint_name("USB/Serial:1\\2") == "USB_Serial_1_2"

--- a/tests/test_symbol_lib_helpers.py
+++ b/tests/test_symbol_lib_helpers.py
@@ -11,6 +11,7 @@ from easyeda2kicad.kicad.export_kicad_symbol import (
     read_symbol_lib_version,
     write_component_in_symbol_lib_file,
 )
+from easyeda2kicad.kicad.parameters_kicad_symbol import sanitize_fields
 
 
 # ---- fixtures ----
@@ -181,3 +182,32 @@ def test_read_version_file_not_found() -> None:
 def test_read_version_none() -> None:
     """None as lib_path falls back to the oldest known version."""
     assert read_symbol_lib_version(None) == 20211014
+
+
+# ---- sanitize_fields ----
+
+
+class TestSanitizeFields:
+    def test_clean_name_unchanged(self) -> None:
+        assert sanitize_fields("STM32F103") == "STM32F103"
+
+    def test_spaces_removed(self) -> None:
+        assert sanitize_fields("USB Bridge") == "USBBridge"
+
+    def test_slash_replaced(self) -> None:
+        assert sanitize_fields("USB/UART") == "USB_UART"
+
+    def test_colon_replaced(self) -> None:
+        assert sanitize_fields("MUX:4to1") == "MUX_4to1"
+
+    def test_backslash_replaced(self) -> None:
+        assert sanitize_fields("A\\B") == "A_B"
+
+    def test_angle_brackets_replaced(self) -> None:
+        assert sanitize_fields("A<->B") == "A_-_B"
+
+    def test_quote_replaced(self) -> None:
+        assert sanitize_fields('say"hi"') == "say_hi_"
+
+    def test_mixed_illegal_chars(self) -> None:
+        assert sanitize_fields('USB/Serial: "Bridge"') == "USB_Serial__Bridge_"

--- a/tests/test_uuid_support.py
+++ b/tests/test_uuid_support.py
@@ -22,7 +22,9 @@ from easyeda2kicad.easyeda.easyeda_importer import (
 # ---------------------------------------------------------------------------
 
 
-def _symbol_data(*, lcsc: dict[str, Any] | None = None, c_para_extra: dict[str, Any] | None = None) -> dict[str, Any]:
+def _symbol_data(
+    *, lcsc: dict[str, Any] | None = None, c_para_extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
     c_para: dict[str, Any] = {"name": "TestPart", "pre": "U", "package": "QFN-32"}
     if c_para_extra:
         c_para.update(c_para_extra)
@@ -40,7 +42,9 @@ def _symbol_data(*, lcsc: dict[str, Any] | None = None, c_para_extra: dict[str, 
     return data
 
 
-def _footprint_data(*, lcsc_number: str = "", c_para_extra: dict[str, Any] | None = None) -> dict[str, Any]:
+def _footprint_data(
+    *, lcsc_number: str = "", c_para_extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
     c_para: dict[str, Any] = {"package": "SOT-23", "name": "TestPart", "pre": "U"}
     if c_para_extra:
         c_para.update(c_para_extra)

--- a/tests/test_uuid_support.py
+++ b/tests/test_uuid_support.py
@@ -22,7 +22,7 @@ from easyeda2kicad.easyeda.easyeda_importer import (
 # ---------------------------------------------------------------------------
 
 
-def _symbol_data(*, lcsc: dict | None = None, c_para_extra: dict | None = None) -> dict:
+def _symbol_data(*, lcsc: dict[str, Any] | None = None, c_para_extra: dict[str, Any] | None = None) -> dict[str, Any]:
     c_para: dict[str, Any] = {"name": "TestPart", "pre": "U", "package": "QFN-32"}
     if c_para_extra:
         c_para.update(c_para_extra)
@@ -40,7 +40,7 @@ def _symbol_data(*, lcsc: dict | None = None, c_para_extra: dict | None = None) 
     return data
 
 
-def _footprint_data(*, lcsc_number: str = "", c_para_extra: dict | None = None) -> dict:
+def _footprint_data(*, lcsc_number: str = "", c_para_extra: dict[str, Any] | None = None) -> dict[str, Any]:
     c_para: dict[str, Any] = {"package": "SOT-23", "name": "TestPart", "pre": "U"}
     if c_para_extra:
         c_para.update(c_para_extra)

--- a/tests/test_uuid_support.py
+++ b/tests/test_uuid_support.py
@@ -1,0 +1,232 @@
+"""Tests for UUID-based component import (--uuid flag, API_ENDPOINT_BY_UUID,
+importer fallbacks for private-component field names)."""
+
+from __future__ import annotations
+
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from easyeda2kicad.__main__ import main, valid_arguments
+from easyeda2kicad.easyeda.easyeda_api import EasyedaApi
+from easyeda2kicad.easyeda.easyeda_importer import (
+    EasyedaFootprintImporter,
+    EasyedaSymbolImporter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _symbol_data(*, lcsc: dict | None = None, c_para_extra: dict | None = None) -> dict:
+    c_para: dict[str, Any] = {"name": "TestPart", "pre": "U", "package": "QFN-32"}
+    if c_para_extra:
+        c_para.update(c_para_extra)
+    data: dict[str, Any] = {
+        "description": "private component",
+        "tags": [],
+        "dataStr": {
+            "BBox": {"x": "0", "y": "0", "width": "10", "height": "10"},
+            "head": {"x": "0", "y": "0", "c_para": c_para},
+            "shape": [],
+        },
+    }
+    if lcsc is not None:
+        data["lcsc"] = lcsc
+    return data
+
+
+def _footprint_data(*, lcsc_number: str = "", c_para_extra: dict | None = None) -> dict:
+    c_para: dict[str, Any] = {"package": "SOT-23", "name": "TestPart", "pre": "U"}
+    if c_para_extra:
+        c_para.update(c_para_extra)
+    return {
+        "SMT": True,
+        "packageDetail": {
+            "title": "SOT-23",
+            "dataStr": {
+                "head": {"x": "0", "y": "0", "c_para": c_para},
+                "shape": [],
+                "canvas": "",
+            },
+        },
+        "lcsc": {"number": lcsc_number},
+        "customData": {},
+        "description": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidArguments:
+    def _base_args(self, **overrides: Any) -> dict[str, Any]:
+        args: dict[str, Any] = {
+            "lcsc_id": None,
+            "uuid": None,
+            "symbol": True,
+            "footprint": False,
+            "3d": False,
+            "svg": False,
+            "full": False,
+            "overwrite": False,
+            "project_relative": False,
+            "output": None,
+            "custom_field": [],
+            "debug": False,
+            "use_cache": False,
+        }
+        args.update(overrides)
+        return args
+
+    def test_neither_lcsc_id_nor_uuid_fails(self) -> None:
+        args = self._base_args()
+        assert valid_arguments(args) is False
+
+    def test_lcsc_id_alone_passes(self, tmp_path: Path) -> None:
+        args = self._base_args(lcsc_id=["C2040"], output=str(tmp_path / "lib"))
+        assert valid_arguments(args) is True
+
+    def test_uuid_alone_passes(self, tmp_path: Path) -> None:
+        args = self._base_args(uuid=["abc-123-def"], output=str(tmp_path / "lib"))
+        assert valid_arguments(args) is True
+
+    def test_both_lcsc_id_and_uuid_passes(self, tmp_path: Path) -> None:
+        args = self._base_args(
+            lcsc_id=["C2040"], uuid=["abc-123-def"], output=str(tmp_path / "lib")
+        )
+        assert valid_arguments(args) is True
+
+    def test_invalid_lcsc_id_format_fails(self, tmp_path: Path) -> None:
+        args = self._base_args(lcsc_id=["12345"], output=str(tmp_path / "lib"))
+        assert valid_arguments(args) is False
+
+    def test_uuid_not_validated_for_c_prefix(self, tmp_path: Path) -> None:
+        args = self._base_args(uuid=["anything-goes"], output=str(tmp_path / "lib"))
+        assert valid_arguments(args) is True
+
+
+# ---------------------------------------------------------------------------
+# Importer: symbol fallbacks for private-component field names
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolImporterFallbacks:
+    def test_supplier_part_used_as_lcsc_number(self) -> None:
+        data = _symbol_data(lcsc={}, c_para_extra={"Supplier Part": "C9999"})
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.lcsc_id == "C9999"
+
+    def test_lcsc_part_used_as_lcsc_number(self) -> None:
+        data = _symbol_data(lcsc={}, c_para_extra={"LCSC Part": "C8888"})
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.lcsc_id == "C8888"
+
+    def test_lcsc_number_takes_priority_over_supplier_part(self) -> None:
+        data = _symbol_data(
+            lcsc={"number": "C1111"},
+            c_para_extra={"Supplier Part": "C9999"},
+        )
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.lcsc_id == "C1111"
+
+    def test_datasheet_link_fallback(self) -> None:
+        data = _symbol_data(
+            lcsc={}, c_para_extra={"link": "https://example.com/ds.pdf"}
+        )
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.datasheet == "https://example.com/ds.pdf"
+
+    def test_datasheet_field_fallback(self) -> None:
+        data = _symbol_data(
+            lcsc={}, c_para_extra={"datasheet": "https://example.com/ds2.pdf"}
+        )
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.datasheet == "https://example.com/ds2.pdf"
+
+    def test_lcsc_url_generated_only_for_c_prefix(self) -> None:
+        data = _symbol_data(lcsc={}, c_para_extra={"Supplier Part": "C7777"})
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.datasheet == "https://www.lcsc.com/datasheet/C7777.pdf"
+
+    def test_no_lcsc_url_for_non_c_prefix_part(self) -> None:
+        data = _symbol_data(lcsc={}, c_para_extra={"Supplier Part": "MOQ1234"})
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.datasheet == ""
+
+    def test_no_datasheet_without_any_source(self) -> None:
+        data = _symbol_data(lcsc={})
+        sym = EasyedaSymbolImporter(data).get_symbol()
+        assert sym.info.datasheet == ""
+
+
+# ---------------------------------------------------------------------------
+# Importer: footprint fallbacks for private-component field names
+# ---------------------------------------------------------------------------
+
+
+class TestFootprintImporterFallbacks:
+    def test_supplier_part_used_as_lcsc_id(self) -> None:
+        data = _footprint_data(lcsc_number="", c_para_extra={"Supplier Part": "C5555"})
+        fp = EasyedaFootprintImporter(data).get_footprint()
+        assert fp.info.lcsc_id == "C5555"
+
+    def test_lcsc_part_used_as_lcsc_id(self) -> None:
+        data = _footprint_data(lcsc_number="", c_para_extra={"LCSC Part": "C4444"})
+        fp = EasyedaFootprintImporter(data).get_footprint()
+        assert fp.info.lcsc_id == "C4444"
+
+    def test_lcsc_number_takes_priority_over_supplier_part(self) -> None:
+        data = _footprint_data(
+            lcsc_number="C1111", c_para_extra={"Supplier Part": "C5555"}
+        )
+        fp = EasyedaFootprintImporter(data).get_footprint()
+        assert fp.info.lcsc_id == "C1111"
+
+    def test_empty_lcsc_id_when_no_fallback(self) -> None:
+        data = _footprint_data(lcsc_number="")
+        fp = EasyedaFootprintImporter(data).get_footprint()
+        assert fp.info.lcsc_id == ""
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end: --uuid routes through without network error
+# ---------------------------------------------------------------------------
+
+
+class TestMainUuidFlow:
+    def test_uuid_flag_error_on_api_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def raise_err(*a: Any, **kw: Any) -> None:
+            raise urllib.error.URLError("no network")
+
+        monkeypatch.setattr("urllib.request.urlopen", raise_err)
+        output = str(tmp_path / "lib")
+        result = main(["--uuid", "bad-uuid", "--symbol", "--output", output])
+        assert result == 1
+
+    def test_no_id_at_all_returns_error(self, tmp_path: Path) -> None:
+        result = main(["--symbol", "--output", str(tmp_path / "lib")])
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Live network: UUID endpoint resolves to correct component
+# ---------------------------------------------------------------------------
+
+
+class TestUuidMatchesLcscId:
+    # C2040's component UUID, extracted from the LCSC API response.
+    C2040_UUID = "c2754a5dac404cb1b757213b56759c67"
+
+    def test_uuid_resolves_to_correct_lcsc_number(self) -> None:
+        api = EasyedaApi()
+        result = api.get_cad_data_of_component(uuid=self.C2040_UUID)
+        assert result.get("lcsc", {}).get("number") == "C2040"


### PR DESCRIPTION
## Summary

- Sanitize illegal characters in footprint and symbol names to prevent
  KiCad import errors
- Add `--uuid` flag to import user-created EasyEDA components that have
  no LCSC part number
- Fix mypy pre-commit hook to scope only production code, resolving a
  pytest 8.x parse error under Python 3.9

## Changes

- `--lcsc_id` is now optional; `--uuid` added alongside it; validation
  requires at least one of the two
- API: `API_ENDPOINT_BY_UUID`; `get_info_from_easyeda_api` and
  `get_cad_data_of_component` accept `lcsc_id | uuid` as optional args
- Importer: fallback chains for `lcsc_number` (symbol + footprint) and
  `datasheet` (symbol) for private-component field names (`"Supplier Part"`,
  `"LCSC Part"`); LCSC datasheet URL guarded by `startswith("C")`
- Tests: 21 new tests covering CLI validation, importer fallbacks, and
  live UUID resolution

## Related

Implements the changes proposed in uPesy/easyeda2kicad.py#198 and
uPesy/easyeda2kicad.py#199, with the following additions:
- Footprint `lcsc_id` fallback (missing in the original PRs)
- mypy pre-commit fix for Python 3.9 + pytest 8.x