### PR TITLE
Fix solid region SVG path parsing

### DIFF
--- a/easyeda2kicad/kicad/export_kicad_footprint.py
+++ b/easyeda2kicad/kicad/export_kicad_footprint.py
@@ -230,22 +230,28 @@ def _parse_solid_region_path(
         cmd = token[0]
         args = [a for a in re.split(r"[,\s]+", token[1:].strip()) if a]
 
-        if cmd == "M" and len(args) >= 2:
-            cur_x, cur_y = float(args[0]), float(args[1])
-            points.append((fp_to_ki(cur_x - bbox_x_px), fp_to_ki(cur_y - bbox_y_px)))
-        elif cmd == "L" and len(args) >= 2:
-            cur_x, cur_y = float(args[0]), float(args[1])
-            points.append((fp_to_ki(cur_x - bbox_x_px), fp_to_ki(cur_y - bbox_y_px)))
+        # append with deduplication, since coordinates seem to be unnecessarily restated sometimes
+        def _append_point():
+            point = (fp_to_ki(cur_x - bbox_x_px), fp_to_ki(cur_y - bbox_y_px))
+            if not points or points[-1] != point:
+                points.append(point)
+
+        # subsequent coordinate pairs are treated as "L" commands,
+        # so "M" is functionally the same as "L" if we only support a single path
+        if cmd in {"M", "L"} and len(args) >= 2:
+            for i in range(0, len(args) - (len(args) % 2), 2):
+                cur_x, cur_y = float(args[i]), float(args[i + 1])
+                _append_point()
         elif cmd == "H" and len(args) >= 1:
             cur_x = float(args[0])
-            points.append((fp_to_ki(cur_x - bbox_x_px), fp_to_ki(cur_y - bbox_y_px)))
+            _append_point()
         elif cmd == "V" and len(args) >= 1:
             cur_y = float(args[0])
-            points.append((fp_to_ki(cur_x - bbox_x_px), fp_to_ki(cur_y - bbox_y_px)))
+            _append_point()
         elif cmd == "A" and len(args) >= 7:
             # Approximate arc by its endpoint only
             cur_x, cur_y = float(args[5]), float(args[6])
-            points.append((fp_to_ki(cur_x - bbox_x_px), fp_to_ki(cur_y - bbox_y_px)))
+            _append_point()
         elif cmd == "Z" and points and points[0] != points[-1]:
             points.append(points[0])
 


### PR DESCRIPTION
This improves the SVG path parsing logic in `_parse_solid_region_path` to be closer to the spec. Specifically, the previous behaviour ignored all coordinate pairs after the first in a command, when they should be interpreted as lineto commands.

Per SVG [spec](https://svgwg.org/specs/paths/#PathDataMovetoCommands) for "M":
> If a moveto is followed by multiple pairs of coordinates, the subsequent pairs are treated as implicit lineto commands. 

And for "L":
> A number of coordinates pairs may be specified to draw a polyline. At the end of the command, the new current point is set to the final set of coordinates provided.

This caused some paths to be missing a point, a test case is the courtyard layer on C2651144, which before the change looked like this:
<img width="649" height="559" alt="image" src="https://github.com/user-attachments/assets/20ce24c7-37d6-4193-9672-55d30e8282b0" />
And after the fix looks like:
<img width="542" height="537" alt="image" src="https://github.com/user-attachments/assets/afd0e8f0-7846-4070-b878-fb72ef6d1d04" />

The path string for this courtyard was: `M397.04725 303.34645 402.95275 303.34645 L402.95275 303.34645 402.95275 296.65355 L402.95275 296.65355 397.04725 296.65355  Z`

This issue interacted with the fact that some of the paths unnecessarily re-state their coordinates (ie providing start, end for each segment even though start is already implied by the end of the previous segment). This meant that it was only drawing the start point of each line segment, causing it to miss one point. Because of this, I also added deduplication to the point adding (and cleaned up all the copy-paste code by putting it in a local function). The difference between "M" and "L" is M starts a new shape and L continues a line segment, since we are just outputting a point list we cannot start a new shape, so they are treated identically.