### PR TITLE
Embed 3D models in generated footprints by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 
-A Python script that converts any electronic components from [EasyEDA](https://easyeda.com/) or [LCSC](https://www.lcsc.com/) to a KiCad library including **3D model** in color. This tool will speed up your PCB design workflow especially when using [JLCPCB SMT assembly services](https://jlcpcb.com/caa). **It supports KiCad v6 and newer.**
+A Python script that converts any electronic components from [EasyEDA](https://easyeda.com/) or [LCSC](https://www.lcsc.com/) to a KiCad library including **3D model** in color. This tool will speed up your PCB design workflow especially when using [JLCPCB SMT assembly services](https://jlcpcb.com/caa). **It supports KiCad v6 and newer; embedded 3D models require KiCad v9 or newer.**
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/uPesy/easyeda2kicad.py/master/ressources/demo_symbol.png" width="500">
@@ -75,6 +75,12 @@ easyeda2kicad --3d --lcsc_id=C2040
 easyeda2kicad --full --lcsc_id C2040 C20197 C163691
 ```
 
+Footprints embed their WRL models by default, making each `.kicad_mod` file self-contained. Use `--no-embed-3d-model` to retain an external `.3dshapes` reference instead, including when targeting KiCad 6–8:
+
+```bash
+easyeda2kicad --footprint --lcsc_id=C2040 --no-embed-3d-model
+```
+
 By default, all libraries are saved in `~/Documents/Kicad/easyeda2kicad/` (Linux/macOS) or `C:/Users/your_name/Documents/Kicad/easyeda2kicad/` (Windows), with:
 
 - `easyeda2kicad.kicad_sym` file for symbol library (KiCad v6+)
@@ -99,12 +105,12 @@ Use `--overwrite` to replace an existing symbol, footprint, or 3D model already 
 easyeda2kicad --full --lcsc_id=C2040 --output ~/libs/my_lib --overwrite
 ```
 
-### Project-relative 3D model paths
+### Project-relative external 3D model paths
 
-When working in a KiCad project folder, use `--project-relative` together with `--output` to store 3D model paths relative to the project root (`${KIPRJMOD}`):
+When using external models in a KiCad project folder, combine `--no-embed-3d-model`, `--project-relative`, and `--output` to store 3D model paths relative to the project root (`${KIPRJMOD}`):
 
 ```bash
-easyeda2kicad --full --lcsc_id=C2040 --output ~/myproject/libs/my_lib --project-relative
+easyeda2kicad --full --lcsc_id=C2040 --output ~/myproject/libs/my_lib --no-embed-3d-model --project-relative
 ```
 
 This stores the 3D path as `${KIPRJMOD}/libs/my_lib.3dshapes/...` instead of an absolute filesystem path, making the project portable.

--- a/docs/CMD_3D_MODEL.md
+++ b/docs/CMD_3D_MODEL.md
@@ -9,10 +9,10 @@ This document describes how 3D models are obtained and integrated into KiCad foo
 ## Workflow Overview
 
 1. Extract UUID and metadata from SVGNODE in footprint data
-2. Download OBJ and STEP files from EasyEDA using UUID
+2. Download OBJ from EasyEDA using UUID, plus STEP for `--3d` or `--full`
 3. Convert OBJ → WRL (VRML) for KiCad visualization
 4. Pass-through STEP files unchanged (binary)
-5. Reference models in footprint with coordinate transformation
+5. Embed the WRL model in the footprint, with an external-reference opt-out
 
 ---
 
@@ -174,7 +174,28 @@ rz = 360 - model_3d.rotation.z
 
 ## KiCad Footprint Integration
 
-**Model Reference:**
+**Embedded model reference (default, KiCad v9+):**
+
+```
+(embedded_files
+  (file
+    (name "IND-SMD_L7.0-W6.6-H3.0.wrl")
+    (type model)
+    (data |<zstd-compressed base64 data>|)
+    (checksum "<KiCad MMH3 checksum>")
+  )
+)
+
+(model "kicad-embed://IND-SMD_L7.0-W6.6-H3.0.wrl"
+  (offset (xyz 0 0 0))
+  (scale (xyz 1 1 1))
+  (rotate (xyz 0 0 0))
+)
+```
+
+The payload is compressed with Zstandard at level 15, Base64 encoded, and wrapped at 76 characters to match KiCad's embedded-file format.
+
+**External model reference (`--no-embed-3d-model`):**
 
 ```
 (model "${EASYEDA2KICAD}/IND-SMD_L7.0-W6.6-H3.0.wrl"
@@ -183,14 +204,16 @@ rz = 360 - model_3d.rotation.z
   (rotate (xyz 0 0 0))
 )
 
-(model "${EASYEDA2KICAD}/IND-SMD_L7.0-W6.6-H3.0.step"
-  (at (xyz 0 0 0))
-  (scale (xyz 1 1 1))
-  (rotate (xyz 0 0 0))
-)
 ```
 
-**File Structure:**
+**Default file structure:**
+
+```
+MyLibrary.pretty/
+  └── Footprint.kicad_mod       # Contains the embedded WRL model
+```
+
+`--full` and `--3d` still write standalone WRL and STEP files. With `--no-embed-3d-model`, footprints refer to those external files:
 
 ```
 MyLibrary.pretty/

--- a/easyeda2kicad/__main__.py
+++ b/easyeda2kicad/__main__.py
@@ -111,6 +111,17 @@ def get_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--embed-3d-model",
+        dest="embed_3d_model",
+        help=(
+            "Embed the WRL model in each footprint (default). Use"
+            " --no-embed-3d-model for an external model reference"
+        ),
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+
+    parser.add_argument(
         "--debug",
         help="set the logging level to debug",
         required=False,
@@ -212,6 +223,7 @@ def _process_component(
         return False
 
     output = arguments["output"]
+    model_exporter: Exporter3dModelKicad | None = None
 
     if arguments["symbol"]:
         # ---------------- SYMBOL ----------------
@@ -256,6 +268,20 @@ def _process_component(
             )
             return False
         footprint_path = Path(f"{output}.pretty")
+        embedded_model_data: str | None = None
+        if arguments["embed_3d_model"] and easyeda_footprint.model_3d is not None:
+            model_3d = easyeda_footprint.model_3d
+            model_3d.raw_obj = api.get_raw_3d_model_obj(uuid=model_3d.uuid)
+            if arguments["3d"]:
+                model_3d.step = api.get_step_3d_model(uuid=model_3d.uuid)
+            model_exporter = Exporter3dModelKicad(model_3d=model_3d)
+            if model_exporter.output and model_exporter.output.raw_wrl:
+                embedded_model_data = model_exporter.output.raw_wrl
+            else:
+                logging.warning(
+                    f"Unable to embed 3D model for {component_id}; using external reference"
+                )
+
         if arguments.get("use_default_folder"):
             model_3d_path = "${EASYEDA2KICAD}/easyeda2kicad.3dshapes"
         elif arguments["project_relative"]:
@@ -269,6 +295,7 @@ def _process_component(
         ExporterFootprintKicad(footprint=easyeda_footprint).export(
             footprint_full_path=str(footprint_path / footprint_filename),
             model_3d_path=model_3d_path,
+            embedded_model_data=embedded_model_data,
         )
         logging.info(
             f"Created Kicad footprint for ID: {component_id}\n"
@@ -297,13 +324,14 @@ def _process_component(
 
     if arguments["3d"]:
         # ---------------- 3D MODEL ----------------
-        model_exporter = Exporter3dModelKicad(
-            model_3d=Easyeda3dModelImporter(
-                easyeda_cp_cad_data=cad_data,
-                download_raw_3d_model=True,
-                api=api,
-            ).output,
-        )
+        if model_exporter is None:
+            model_exporter = Exporter3dModelKicad(
+                model_3d=Easyeda3dModelImporter(
+                    easyeda_cp_cad_data=cad_data,
+                    download_raw_3d_model=True,
+                    api=api,
+                ).output,
+            )
         output_dir = Path(f"{output}.3dshapes")
         if not model_exporter.output:
             logging.warning(f"No 3D model available for ID: {component_id}")

--- a/easyeda2kicad/kicad/embedded_files.py
+++ b/easyeda2kicad/kicad/embedded_files.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import base64
+import struct
+import textwrap
+
+import zstandard
+
+_HASH_SEED = 0xABBA2345
+_MASK_64 = (1 << 64) - 1
+_MIME_BASE64_LENGTH = 76
+
+
+def _rotate_left_64(value: int, bits: int) -> int:
+    return ((value << bits) | (value >> (64 - bits))) & _MASK_64
+
+
+def _fmix_64(value: int) -> int:
+    value ^= value >> 33
+    value = (value * 0xFF51AFD7ED558CCD) & _MASK_64
+    value ^= value >> 33
+    value = (value * 0xC4CEB9FE1A85EC53) & _MASK_64
+    value ^= value >> 33
+    return value
+
+
+def kicad_embedded_checksum(data: bytes) -> str:
+    """Return the checksum used by KiCad's embedded-file container.
+
+    KiCad uses its streaming MMH3_HASH implementation with a fixed seed. Its
+    tail padding differs from the usual one-shot MurmurHash3 x64-128 function,
+    so this deliberately mirrors KiCad rather than using a generic hash module.
+    """
+    c1 = 0x87C37B91114253D5
+    c2 = 0x4CF5AD432745937F
+    h1 = _HASH_SEED
+    h2 = _HASH_SEED
+
+    offset = 0
+    while len(data) - offset >= 16:
+        k1, k2 = struct.unpack_from("<QQ", data, offset)
+
+        k1 = (k1 * c1) & _MASK_64
+        k1 = _rotate_left_64(k1, 31)
+        k1 = (k1 * c2) & _MASK_64
+        h1 ^= k1
+
+        h1 = _rotate_left_64(h1, 27)
+        h1 = (h1 + h2) & _MASK_64
+        h1 = (h1 * 5 + 0x52DCE729) & _MASK_64
+
+        k2 = (k2 * c2) & _MASK_64
+        k2 = _rotate_left_64(k2, 33)
+        k2 = (k2 * c1) & _MASK_64
+        h2 ^= k2
+
+        h2 = _rotate_left_64(h2, 31)
+        h2 = (h2 + h1) & _MASK_64
+        h2 = (h2 * 5 + 0x38495AB5) & _MASK_64
+
+        offset += 16
+
+    remaining = len(data) - offset
+    padding = 4 - ((remaining + 4) % 4) if remaining else 0
+    padded_length = len(data) + padding
+    tail_size = padded_length & 15
+
+    if tail_size:
+        tail = data[offset:] + bytes(padding)
+        k1 = int.from_bytes(tail[: min(tail_size, 8)], "little")
+        k1 = (k1 * c1) & _MASK_64
+        k1 = _rotate_left_64(k1, 31)
+        k1 = (k1 * c2) & _MASK_64
+        h1 ^= k1
+
+        if tail_size > 8:
+            k2 = int.from_bytes(tail[8:tail_size], "little")
+            k2 = (k2 * c2) & _MASK_64
+            k2 = _rotate_left_64(k2, 33)
+            k2 = (k2 * c1) & _MASK_64
+            h2 ^= k2
+
+    h1 ^= padded_length
+    h2 ^= padded_length
+    h1 = (h1 + h2) & _MASK_64
+    h2 = (h2 + h1) & _MASK_64
+    h1 = _fmix_64(h1)
+    h2 = _fmix_64(h2)
+    h1 = (h1 + h2) & _MASK_64
+    h2 = (h2 + h1) & _MASK_64
+
+    return f"{h1:016X}{h2:016X}"
+
+
+def format_embedded_model(name: str, data: str | bytes) -> str:
+    """Format a WRL model using KiCad's embedded-files S-expression."""
+    model_data = data.encode("utf-8") if isinstance(data, str) else data
+    compressed = zstandard.ZstdCompressor(level=15).compress(model_data)
+    encoded = base64.b64encode(compressed).decode("ascii")
+    chunks = textwrap.wrap(encoded, width=_MIME_BASE64_LENGTH)
+    escaped_name = name.replace("\\", "\\\\").replace('"', '\\"')
+
+    output = (
+        "\t(embedded_fonts no)\n"
+        "\t(embedded_files\n"
+        "\t\t(file\n"
+        f'\t\t\t(name "{escaped_name}")\n'
+        "\t\t\t(type model)\n"
+    )
+
+    for index, chunk in enumerate(chunks):
+        prefix = "\t\t\t(data |" if index == 0 else "\t\t\t\t"
+        suffix = "|\n" if index == len(chunks) - 1 else "\n"
+        output += f"{prefix}{chunk}{suffix}"
+
+    output += (
+        "\t\t\t)\n"
+        f'\t\t\t(checksum "{kicad_embedded_checksum(model_data)}")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    return output

--- a/easyeda2kicad/kicad/export_kicad_footprint.py
+++ b/easyeda2kicad/kicad/export_kicad_footprint.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # Local imports
 from ..easyeda.parameters_easyeda import EeFootprint, EeFootprintSolidRegion
+from .embedded_files import format_embedded_model
 from .parameters_kicad_footprint import (
     KI_ARC,
     KI_CIRCLE,
@@ -587,6 +588,7 @@ class ExporterFootprintKicad:
         footprint_full_path: str,
         model_3d_path: str,
         model_3d_extension: str = "wrl",
+        embedded_model_data: str | bytes | None = None,
     ) -> None:
         ki = self.output
         ki_lib = ""
@@ -669,8 +671,18 @@ class ExporterFootprintKicad:
                 ki_lib += KI_FP_POLY.format(pts=pts_str, layer=region.layer)
 
         if ki.model_3d is not None:
+            model_filename = f"{ki.model_3d.name}.{model_3d_extension}"
+            if embedded_model_data is not None:
+                ki_lib += format_embedded_model(
+                    name=model_filename,
+                    data=embedded_model_data,
+                )
+                model_reference = f"kicad-embed://{model_filename}"
+            else:
+                model_reference = f"{model_3d_path}/{model_filename}"
+
             ki_lib += KI_MODEL_3D.format(
-                file_3d=f"{model_3d_path}/{ki.model_3d.name}.{model_3d_extension}",
+                file_3d=model_reference,
                 pos_x=ki.model_3d.translation.x,
                 pos_y=ki.model_3d.translation.y,
                 pos_z=ki.model_3d.translation.z,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pre-commit>=3.0.0
+zstandard>=0.21.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     package_dir={"easyeda2kicad": "easyeda2kicad"},
     entry_points={"console_scripts": ["easyeda2kicad = easyeda2kicad.__main__:main"]},
     python_requires=">=3.9",
-    install_requires=[],
+    install_requires=["zstandard>=0.21.0"],
     extras_require={
         "dev": [
             "pre-commit>=3.0.0",

--- a/tests/test_embedded_models.py
+++ b/tests/test_embedded_models.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import base64
+import re
+
+import zstandard
+
+from easyeda2kicad.__main__ import get_parser
+from easyeda2kicad.easyeda.parameters_easyeda import (
+    Ee3dModel,
+    Ee3dModelBase,
+    EeFootprint,
+    EeFootprintBbox,
+    EeFootprintInfo,
+)
+from easyeda2kicad.kicad.embedded_files import (
+    format_embedded_model,
+    kicad_embedded_checksum,
+)
+from easyeda2kicad.kicad.export_kicad_footprint import ExporterFootprintKicad
+
+MODEL_DATA = b"#VRML V2.0 utf8\nShape {}\n"
+
+
+def _footprint_with_model() -> EeFootprint:
+    return EeFootprint(
+        info=EeFootprintInfo(
+            name="TEST_FOOTPRINT",
+            fp_type="smd",
+            model_3d_name="Test Model",
+        ),
+        bbox=EeFootprintBbox(x=0, y=0),
+        model_3d=Ee3dModel(
+            name="Test Model",
+            uuid="model-uuid",
+            translation=Ee3dModelBase(),
+            rotation=Ee3dModelBase(),
+        ),
+    )
+
+
+def test_embed_3d_model_is_enabled_by_default() -> None:
+    parser = get_parser()
+    default_args = parser.parse_args(["--lcsc_id", "C1", "--footprint"])
+    external_args = parser.parse_args(
+        ["--lcsc_id", "C1", "--footprint", "--no-embed-3d-model"]
+    )
+
+    assert default_args.embed_3d_model is True
+    assert external_args.embed_3d_model is False
+
+
+def test_kicad_embedded_checksum_matches_known_value() -> None:
+    assert (
+        kicad_embedded_checksum(MODEL_DATA)
+        == "5AE369D6E830F6B533847216BB6D0518"
+    )
+
+
+def test_embedded_model_payload_round_trips() -> None:
+    embedded = format_embedded_model(name="Test Model.wrl", data=MODEL_DATA)
+    encoded = re.search(r"\(data \|(.*?)\|", embedded, flags=re.DOTALL)
+
+    assert encoded is not None
+    compressed = base64.b64decode("".join(encoded.group(1).split()))
+    assert zstandard.ZstdDecompressor().decompress(compressed) == MODEL_DATA
+    assert '(name "Test Model.wrl")' in embedded
+    assert "(type model)" in embedded
+    assert '(checksum "5AE369D6E830F6B533847216BB6D0518")' in embedded
+
+
+def test_footprint_export_uses_embedded_model_uri(tmp_path) -> None:
+    output = tmp_path / "TEST_FOOTPRINT.kicad_mod"
+    ExporterFootprintKicad(footprint=_footprint_with_model()).export(
+        footprint_full_path=str(output),
+        model_3d_path="/external/models",
+        embedded_model_data=MODEL_DATA,
+    )
+    footprint = output.read_text(encoding="utf-8")
+
+    assert "(embedded_fonts no)" in footprint
+    assert "(embedded_files" in footprint
+    assert '(model "kicad-embed://Test Model.wrl"' in footprint
+    assert "/external/models" not in footprint
+
+
+def test_footprint_export_can_keep_external_model_reference(tmp_path) -> None:
+    output = tmp_path / "TEST_FOOTPRINT.kicad_mod"
+    ExporterFootprintKicad(footprint=_footprint_with_model()).export(
+        footprint_full_path=str(output),
+        model_3d_path="/external/models",
+    )
+    footprint = output.read_text(encoding="utf-8")
+
+    assert "(embedded_files" not in footprint
+    assert '(model "/external/models/Test Model.wrl"' in footprint


### PR DESCRIPTION
## Summary

- embed generated WRL models directly in footprint files using the KiCad embedded-files format
- add --embed-3d-model and --no-embed-3d-model flags, with embedding enabled by default
- reuse the model download during --full and retain external model output for --3d
- document the KiCad 9 requirement and add checksum, compression, exporter, and CLI tests

## Verification

- 182 tests passed on Python 3.9; 69 reference-fixture tests skipped
- all pre-commit lint, format, and mypy hooks passed
- package sdist and wheel build passed
- a generated C2040 footprint loaded successfully with the KiCad 10 PCB parser
- the legacy external-reference path was verified with --no-embed-3d-model