### PR TITLE
fix: prevent duplicate symbols caused by unsanitized name lookup

### DIFF
--- a/easyeda2kicad/kicad/export_kicad_symbol.py
+++ b/easyeda2kicad/kicad/export_kicad_symbol.py
@@ -37,6 +37,7 @@ from .parameters_kicad_symbol import (
     KiSymbolPolygon,
     KiSymbolRectangle,
     KiSymbolText,
+    sanitize_fields,
 )
 
 _SYM_LIB_REGEX = r'\n(\s*)\(symbol "{component_name}".*?\n\1\)(?=\n|$)'
@@ -670,6 +671,15 @@ class ExporterSymbolKicad:
             ee_symbol=self.input, custom_fields=custom_fields
         )
 
+    @property
+    def component_name(self) -> str:
+        """Name this symbol is written under in the .kicad_sym file.
+
+        Sanitized like KiSymbol.export() renders it, so lookups still match
+        when the raw name contains a space, "/" or ":".
+        """
+        return sanitize_fields(self.input.info.name)
+
     def export(self, footprint_lib_name: str) -> str:
         tune_footprint_ref_path(
             ki_symbol=self.output,
@@ -689,7 +699,7 @@ class ExporterSymbolKicad:
         return integrate_sub_units(
             main_symbol=main_content,
             sub_symbols=sub_contents,
-            component_name=self.input.info.name,
+            component_name=self.component_name,
         )
 
     def save_to_lib(
@@ -700,7 +710,7 @@ class ExporterSymbolKicad:
         Returns False if the symbol already exists and overwrite is False.
         """
         already_exists = id_already_in_symbol_lib(
-            lib_path=lib_path, component_name=self.input.info.name
+            lib_path=lib_path, component_name=self.component_name
         )
         if already_exists and not overwrite:
             return False
@@ -708,7 +718,7 @@ class ExporterSymbolKicad:
         content = self.export(footprint_lib_name=footprint_lib_name)
         write_component_in_symbol_lib_file(
             lib_path=lib_path,
-            component_name=self.input.info.name,
+            component_name=self.component_name,
             component_content=content,
             version=self.version,
         )

--- a/tests/test_symbol_lib_helpers.py
+++ b/tests/test_symbol_lib_helpers.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
+from easyeda2kicad.easyeda.parameters_easyeda import (
+    EeSymbol,
+    EeSymbolBbox,
+    EeSymbolInfo,
+)
 from easyeda2kicad.kicad.export_kicad_symbol import (
+    ExporterSymbolKicad,
     id_already_in_symbol_lib,
     read_symbol_lib_version,
     write_component_in_symbol_lib_file,
@@ -29,6 +35,10 @@ V6_SYMBOL_A = """\
     )
   )
 """
+
+# LCSC C7421520 — sanitize_fields() strips the space
+SPACED_NAME = "2.54-3P TPGT"
+SANITIZED_NAME = "2.54-3PTPGT"
 
 V6_SYMBOL_B = """\
 
@@ -133,6 +143,39 @@ def test_write_two_then_overwrite_first_unchanged(v6_lib_with_a: Path) -> None:
     assert content_after.count('(symbol "CompA"') == 1
     assert content_after.count('(symbol "CompB"') == 1
     assert content_before.strip() == content_after.strip()
+
+
+# ---- names needing sanitization ----
+
+
+def _spaced_symbol() -> EeSymbol:
+    return EeSymbol(
+        info=EeSymbolInfo(name=SPACED_NAME, prefix="J?", package="HDR-3P"),
+        bbox=EeSymbolBbox(x=0.0, y=0.0, width=0.0, height=0.0),
+    )
+
+
+def _save(lib: Path, overwrite: bool) -> bool:
+    exporter = ExporterSymbolKicad(symbol=_spaced_symbol(), lib_path=str(lib))
+    return exporter.save_to_lib(
+        lib_path=str(lib), footprint_lib_name="test", overwrite=overwrite
+    )
+
+
+def test_spaced_name_second_write_is_detected(v6_lib: Path) -> None:
+    """Without --overwrite, a re-import of a spaced name must be refused."""
+    assert _save(v6_lib, overwrite=False) is True
+    assert _save(v6_lib, overwrite=False) is False
+
+
+def test_spaced_name_overwrite_does_not_duplicate(v6_lib: Path) -> None:
+    """--overwrite must replace the symbol, not append a second copy."""
+    _save(v6_lib, overwrite=True)
+    _save(v6_lib, overwrite=True)
+
+    content = v6_lib.read_text(encoding="utf-8")
+    assert content.count(f'(symbol "{SANITIZED_NAME}"') == 1
+    assert f'(symbol "{SPACED_NAME}"' not in content
 
 
 # ---- read_symbol_lib_version ----


### PR DESCRIPTION
This MR fixes the creation of duplicate symbols when the name contains spaces (or other special chars) that get stripped away.

Example:
```console
foo@bar:~$ uvx easyeda2kicad --symbol --lcsc_id C7421520 --output ./lib --overwrite # (4x)
foo@bar:~$ rg "2.54-3PTPGT_0_1" lib.kicad_sym 
57:    (symbol "2.54-3PTPGT_0_1"
303:    (symbol "2.54-3PTPGT_0_1"
549:    (symbol "2.54-3PTPGT_0_1"
795:    (symbol "2.54-3PTPGT_0_1"
```

Fixes https://github.com/uPesy/easyeda2kicad.py/issues/211